### PR TITLE
feat(next-queries): update adapter

### DIFF
--- a/src/x-components/adapter.ts
+++ b/src/x-components/adapter.ts
@@ -13,5 +13,11 @@ export const adapter = new EmpathyAdapterBuilder()
       totalResults: 'catalog.numFound'
     }
   })
+  .setFeatureConfig('nextQueries', {
+    endpoint: 'https://search.internal.test.empathy.co/query/empathy/nextqueries',
+    responsePaths: {
+      nextQueries: 'data.nextQueries'
+    }
+  })
   .setInstance('platform')
   .build();


### PR DESCRIPTION
EX-4057

In order to read the new next queries from the platform API, we need to update the adapter, this PR fix this.