### PR TITLE
Feature/ex 4187 the sort dropdown is overlapped 

### DIFF
--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -179,10 +179,3 @@
     public spellcheckedQuery!: string;
   }
 </script>
-
-<style>
-  /* TODO try to find a solution to position absolute issue */
-  .x-grid .x-staggered-fade-and-slide--leave-active {
-    position: unset !important;
-  }
-</style>

--- a/src/components/toolbar.vue
+++ b/src/components/toolbar.vue
@@ -9,7 +9,12 @@
       <span v-else>{{ column }}</span>
     </ColumnPicker>
 
-    <SortDropdown v-if="$x.totalResults" class="x-dropdown--l" :items="sortValues">
+    <SortDropdown
+      v-if="$x.totalResults"
+      class="x-dropdown--l"
+      :items="sortValues"
+      :animation="collapseFromTop"
+    >
       <template #toggle="{ item, isOpen }">
         <span>{{ $t('sort.label') }}</span>
         <!--TODO: remove the `x-text` class when this task done:
@@ -36,7 +41,8 @@
     BaseColumnPickerList,
     CheckTinyIcon,
     ChevronTinyDownIcon,
-    ChevronTinyUpIcon
+    ChevronTinyUpIcon,
+    CollapseFromTop
   } from '@empathy/x-components';
   import { Component, Vue } from 'vue-property-decorator';
   import { Sort } from '@empathy/search-types';
@@ -54,5 +60,7 @@
   export default class SortComponent extends Vue {
     public columnsValues: number[] = [4, 6, 0];
     public sortValues: Sort[] = ['', 'price asc', 'price desc'];
+
+    protected collapseFromTop = CollapseFromTop;
   }
 </script>


### PR DESCRIPTION
# Description

Two different commits:
- main.vue: removed CSS done in the past to fix something related to the staggered fade and slide animation.
- toolbar.vue: add CollapseFromTop transition.

I forgot to put the task https://searchbroker.atlassian.net/browse/EX-4187 as the body, so please add it in the PR message.

Initially, the task describes an issue that I haven't been able to reproduce. Please, check if it happens to you but it seems that it has been fixed.

Testing it (you have to animate the sort dropdown), I noticed that something was wrong because there was a delay, pause between the start and the end of the sort animation if I use CollapseHeight. It seems to be a performance issue that doesn't happen with CollapseFromTop animation which uses scale instead of modifying the height.

# Motivation

Related issue from the original described in the task that I couldn't reproduce.

# Test

Run the server and check if the sort dropdown is overlapping any result element; check also the animation.