### PR TITLE
feature(layout): add dir rtl to main modal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
       class="x-modal"
       modalId="x-components-app"
       :animation="collapseFromTop"
+      dir="ltr"
     >
       <Main />
     </BaseIdModal>

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
       class="x-modal"
       modalId="x-components-app"
       :animation="collapseFromTop"
-      dir="ltr"
+      :dir="documentDirection"
     >
       <Main />
     </BaseIdModal>
@@ -17,8 +17,14 @@
 
 <script lang="ts">
   import { DeviceDetector } from '@empathy/x-components/device';
-  import { Component, Vue } from 'vue-property-decorator';
-  import { BaseIdModalOpen, BaseIdModal, CollapseFromTop, Dictionary } from '@empathy/x-components';
+  import { Component, Inject, Vue } from 'vue-property-decorator';
+  import {
+    BaseIdModalOpen,
+    BaseIdModal,
+    CollapseFromTop,
+    Dictionary,
+    SnippetConfig
+  } from '@empathy/x-components';
   import Main from './components/main.vue';
   import '@empathy/x-components/design-system/full-theme.css';
   import './design-system/tokens.scss';
@@ -39,6 +45,13 @@
       tablet: 900,
       desktop: Number.POSITIVE_INFINITY
     };
+
+    @Inject('snippetConfig')
+    protected snippetConfig!: SnippetConfig;
+
+    protected get documentDirection(): string {
+      return this.snippetConfig.documentDirection ?? 'ltr';
+    }
   }
 </script>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -50,7 +50,11 @@
     protected snippetConfig!: SnippetConfig;
 
     protected get documentDirection(): string {
-      return this.snippetConfig.documentDirection ?? 'ltr';
+      return (
+        document.documentElement.dir ||
+        document.body.dir ||
+        (this.snippetConfig.documentDirection ?? 'ltr')
+      );
     }
   }
 </script>


### PR DESCRIPTION
# Description

This task was originally intended to solve a problem in which PostCSS logical, a plugin that transforms logical CSS properties to physical properties and that it's run during the build, didn't create CSS fallback rules without [dir="..."] attributes.

The library doesn't support it and the creators mention it explicitly so we have to manage and add the dir attribute directly.

# Motivation

This task came from an issue that appeared solving a task from the Archetype issues.

# Test

Switch between ltr and rtl and check that it has effect. 