### PR TITLE
build: Remove `__EXTRACTED_CSS__` in favour of html plugin order

### DIFF
--- a/build/instrumentation.build.js
+++ b/build/instrumentation.build.js
@@ -68,15 +68,6 @@ export function createConfig({
           targets: [`${jsOutputDirectory}/*`]
         })
       ),
-      htmlTemplate(
-        mergeConfig('htmlTemplate', {
-          template: path.resolve(process.cwd(), 'public/index.html'),
-          target: 'index.html',
-          replaceVars: {
-            __EXTRACTED_CSS__: extractCss ? `<link href="${outputCss}" rel="stylesheet"/>` : ''
-          }
-        })
-      ),
       copy({
         targets: [{ src: ['public/**', '!public/index.html'], dest: 'dist/' }]
       }),
@@ -119,6 +110,11 @@ export function createConfig({
         mergeConfig('styles', {
           mode: extractCss ? ['extract', outputCss] : 'inject',
           plugins: postCSSPlugins
+        })
+      ),
+      htmlTemplate(
+        mergeConfig('htmlTemplate', {
+          template: path.resolve(process.cwd(), 'public/index.html')
         })
       ),
       sourcemaps(mergeConfig('sourcemaps')),

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,6 @@
       href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&display=swap"
       rel="stylesheet"
     />
-    __EXTRACTED_CSS__
   </head>
   <body style="background: lightgrey">
     <script src="./snippet-script.js"></script>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ export default createConfig({
     input: Check input options at http://rollupjs.org/guide/en/#input
     output: Check all output options at http://rollupjs.org/guide/en/#outputdir
   */
+  extractCss: true,
   plugins: {
     // Modify plugins options here.
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,6 @@ export default createConfig({
     input: Check input options at http://rollupjs.org/guide/en/#input
     output: Check all output options at http://rollupjs.org/guide/en/#outputdir
   */
-  extractCss: true,
   plugins: {
     // Modify plugins options here.
   }


### PR DESCRIPTION
I realised yesterday in the night that the html plugin was above the styles plugin, so it was impossible for it to detect if it had to link the CSS. After doing this, the `__EXTRACTED_CSS__` trick is no longer necessary.