### PR TITLE
docs: add issue templates and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence,
+# These owners will be requested for review when someone opens a pull request.
+
+* @empathyco/x

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+x@empathy.co.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+---
+name: Bug report
+description: Create a report to help us improve
+title: "[BUG]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: "Thank you for taking the time to provide feedback!"
+  - type: markdown
+    attributes:
+     value: Before creating a new bug, please check for [existing issues](https://github.com/empathyco/x-archetype/issues).
+  - type: textarea
+    id: bug-environment
+    attributes:
+      label: Environment affected
+      description: Provide specific details regarding where the bug occurred and the access used.
+      placeholder: e.g. customer name, environment, URL, access details (user name and password), OS, browser (including version)
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Description
+      description: Provide a clear and concise description of what you are experiencing.
+      placeholder: e.g. The filters are not filtering.
+  - type: textarea
+    id: bug-current-behavior
+    attributes:
+      label: Current behavior and expected result
+      description: Describe what is currently happening, giving details on what you expected to happen.
+  - type: textarea
+    id: bug-steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: e.g. 1. Search for `gravel`. / 2. Expand the filters panel. / 3. In facet `Category`, click the filter `Long Distance`. / 4. The results do not change.
+  - type: textarea
+    id: bug-info
+    attributes:
+      label: Supporting information
+      description: Provide as much supporting information as possible. Including attachments will help us to better understand the issue.
+      placeholder: Include supporting documentation, e.g. designs, diagrams, videos, Confluence links, real examples.
+  - type: checkboxes
+    id: bug-terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](./../CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+---
+name: Feature request
+description: Add a new suggestion for feature
+title: "[FEATURE]: "
+labels: [feature,enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: "Welcome!"
+  - type: markdown
+    attributes:
+     value: When suggesting a new feature for the Interface X project, submit your idea as a user story and provide as much information as possible on how you would solve it, so the team can assess and analyze your idea.    
+      When defining your new feature, you need to consider it from two points of view. 
+      
+      - the **Final User** who accesses the commerce website that uses the component.  
+
+      - the **Developer User** who is going to use the component to build a website.  
+      
+      Depending on the feature, you may need to consider one or both.
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: How can the project be improved?
+      description: Describe the problem encountered, what you need to solve it, and what you expect. Include details of other requirements that the feature must cover such as dependencies and actions covered by other services.
+      placeholder:
+        e.g. Display a list of search queries already performed by the user. / Each search query of the list has a button to delete it from the list. / The list of search queries must be maintained in the same device over time, even when the tab is closed. / If there are no search queries, then nothing should be displayed.
+  - type: textarea
+    id: solution
+    attributes:
+      label: How can this be solved?
+      description: Explain the different interactions of the user.
+      placeholder: e.g. When the user clicks on an item of the list, then that search query is performed. / When the user clicks on the delete button, then the search query is removed from the list.
+  - type: textarea
+    id: feature-proposal
+    attributes:
+      label: Proposed solution
+      description: If you have any suggestions regarding how this need can be covered, please provide details here.
+  - type: textarea
+    id: feature-customizations
+    attributes:
+      label: Customizations supported
+      description: Provide ideas for customizations that can be performed by the developer
+      placeholder: e.g. Change the content of each search query / Change the complete content of the item  / Add different animation to items / Change the number of the search queries to show
+  - type: textarea
+    id: feature-info
+    attributes:
+      label: Additional information
+      description: Provide as much supporting information as possible. Including attachments will help us to better understand your feature request and requirements.
+      placeholder: e.g. designs, diagrams, videos, Confluence links, real examples
+  - type: checkboxes
+    id: feature-terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](./../CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--Please provide a general summary of changes in the PR title -->
+
+# Pull request template
+<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
+Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.
+
+## Motivation and context
+<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
+
+<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->
+
+- [ ] Dependencies. If any, specify:
+- [ ] Open issue. If applicable, link:
+
+## Type of change
+<!-- Indicate the type of change involved in the PR -->
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
+- [ ] Change requires a documentation update
+
+## What is the destination branch of this PR?
+<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
+- [ ] `Main`
+- [ ] Other. Specify:
+
+## How has this been tested?
+
+<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
+
+Tests performed according to [testing guidelines](https://github.com/empathyco/x/blob/main/.github/contributing/tests.md): 
+
+## Checklist:
+
+- [ ] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
+- [ ] I have performed a **self-review** on my own code.
+- [ ] I have **commented** my code, particularly in hard-to-understand areas.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] My changes generate **no new warnings**.
+- [ ] I have added **tests** that prove my fix is effective or that my feature works.
+- [ ] New and existing **unit tests pass locally** with my changes.


### PR DESCRIPTION
We were missing some documentation on this repo:

Codeowners to automatically ask for review to the X Team.
Issue templates to create features and bugs.
Pull Request template, as you can see the poor layout on this PR.
Code of Conduct as we have on Interface X repository.

We should iterate on this at some point and add the Contibuting Guidelines, and maube link to the Style Guide in the X Repo, but i didnt want to open that watermelon on this PR.