### PR TITLE
build: remove `polyfills` support

### DIFF
--- a/build/instrumentation.build.js
+++ b/build/instrumentation.build.js
@@ -58,7 +58,7 @@ export function createConfig({
       format: 'es',
       sourcemap: true,
       assetFileNames: '[name][extname]',
-      entryFileNames: 'x-core.js',
+      entryFileNames: 'app.js',
       chunkFileNames: chunkInfo => {
         switch (chunkInfo.name) {
           case 'x-modal':
@@ -136,5 +136,3 @@ export function createConfig({
     ]
   };
 }
-
-export default createConfig();

--- a/build/instrumentation.build.js
+++ b/build/instrumentation.build.js
@@ -14,7 +14,6 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import visualizer from 'rollup-plugin-visualizer';
 import vue from 'rollup-plugin-vue';
-import polyFillsWrapper from '../node_modules/@empathyco/x-components/build-helpers/plugins/polyfills-wrapper.plugin';
 
 const jsOutputDirectory = path.join(process.cwd(), 'dist');
 
@@ -59,11 +58,9 @@ export function createConfig({
       format: 'es',
       sourcemap: true,
       assetFileNames: '[name][extname]',
-      entryFileNames: 'app.js',
+      entryFileNames: 'x-core.js',
       chunkFileNames: chunkInfo => {
         switch (chunkInfo.name) {
-          case 'main':
-            return 'x-core-[hash].js';
           case 'x-modal':
             return 'x-empty-search-[hash].js';
           case 'index':
@@ -74,7 +71,7 @@ export function createConfig({
       },
       ...output
     },
-    preserveEntrySignatures: 'strict',
+    preserveEntrySignatures: false,
     plugins: [
       del(
         mergeConfig('del', {
@@ -128,7 +125,6 @@ export function createConfig({
         })
       ),
       sourcemaps(mergeConfig('sourcemaps')),
-      polyFillsWrapper(mergeConfig('polyfillsWrapper')),
       terser(
         mergeConfig('terser', {
           output: { comments: false }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@empathyco/x-adapter": "^7.0.0-alpha.9",
-        "@empathyco/x-components": "^3.0.0-alpha.55",
+        "@empathyco/x-components": "^3.0.0-alpha.63",
         "@empathyco/x-types": "^10.0.0-alpha.14",
         "reflect-metadata": "^0.1.13",
         "tslib": "~2.3.0",
@@ -2304,15 +2304,15 @@
       }
     },
     "node_modules/@empathyco/x-adapter": {
-      "version": "7.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-7.0.0-alpha.11.tgz",
-      "integrity": "sha512-Hf+AUNuIt8FOLlvfQrvGFq5SdCBfxGuP+5wHdkIJVofCHhCjEY8AMuqYlJQdgwgXuE+yBpO1VjvIVpKKe/yQzA==",
+      "version": "7.0.0-alpha.13",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-7.0.0-alpha.13.tgz",
+      "integrity": "sha512-8GOli9ES1U+PbhQKzy4kTxOH7x2uhzH2tx3sRVa7ISBw9yxNKInmWoMXAAq3h60+db6PuZIy5YczSj2TQaKPtw==",
       "dependencies": {
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.1",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.2",
         "@empathyco/x-get-safe-property-chain": "^1.3.0-alpha.1",
         "@empathyco/x-logger": "^1.1.0",
         "@empathyco/x-storage-service": "^2.0.0-alpha.0",
-        "@empathyco/x-types": "^10.0.0-alpha.15",
+        "@empathyco/x-types": "^10.0.0-alpha.17",
         "inversify": "~5.0.1",
         "reflect-metadata": "~0.1.13",
         "tslib": "~2.3.0"
@@ -2322,18 +2322,17 @@
       }
     },
     "node_modules/@empathyco/x-components": {
-      "version": "3.0.0-alpha.55",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.55.tgz",
-      "integrity": "sha512-FtFC/oAVCcacpmvOOvWhFKk+0xoPKEQx+aXgJ1ddrGiP+a+izmejw4RUdzidfYHtJEpPm/xh18BMSGgRMbtH1A==",
+      "version": "3.0.0-alpha.63",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.63.tgz",
+      "integrity": "sha512-x1HUdk/wzllnceSo4cINnCBgtC6hO2dRtPbdHMlqloDTiobOlujsSmbTzy4n7yXVOH2+H5rHNDE2lNy7ZV1WnA==",
       "dependencies": {
-        "@empathyco/x-adapter": "^7.0.0-alpha.11",
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.1",
+        "@empathyco/x-adapter": "^7.0.0-alpha.13",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.2",
         "@empathyco/x-logger": "^1.2.0-alpha.1",
         "@empathyco/x-storage-service": "^2.0.0-alpha.0",
-        "@empathyco/x-types": "^10.0.0-alpha.15",
+        "@empathyco/x-types": "^10.0.0-alpha.17",
         "@types/resize-observer-browser": "~0.1.5",
-        "magic-string": "~0.25.7",
-        "nanoid": "~3.1.30",
+        "nanoid": "~3.1.31",
         "reflect-metadata": "~0.1.13",
         "rxjs": "~7.4.0",
         "tslib": "~2.3.0",
@@ -2354,9 +2353,9 @@
       }
     },
     "node_modules/@empathyco/x-deep-merge": {
-      "version": "1.3.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-deep-merge/-/x-deep-merge-1.3.0-alpha.1.tgz",
-      "integrity": "sha512-tThLvh7pBVgohAr3nKdECpufUVjIbytg2oSjIelGmHVYWIDHLSOxHp9q0AbmJeOMMwMKXyEJl3PqjngklBt5Fg==",
+      "version": "1.3.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-deep-merge/-/x-deep-merge-1.3.0-alpha.2.tgz",
+      "integrity": "sha512-HrKe9OIuUf+Nh1V3HgxGUgEw+f1SS2Cr4/zRA4J4e1xhWNYA3xE+iGYmtlvZjjn+nE5RG29yoTobBjeW4xV4tA==",
       "dependencies": {
         "tslib": "~2.3.0"
       },
@@ -2419,9 +2418,9 @@
       }
     },
     "node_modules/@empathyco/x-types": {
-      "version": "10.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.15.tgz",
-      "integrity": "sha512-kr8zyeLcmzsmk8pOl0vqfot2KYulPQXBBdrKm+i6GjxVJa0+JvnjlF5qatNCukRkddKwi3pQbtyupf3NNx7W/g==",
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-xm0zcVMBbZn7lSyaOVxwKL7sOykYxKwldrS4jXi4vYI7V8Hr0RjDnPLJKNAGuupYFvxwoMlpM0rF6Yyl95OSyg==",
       "dependencies": {
         "tslib": "~2.3.0"
       },
@@ -20484,6 +20483,7 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -27483,7 +27483,8 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/spawn-command": {
       "version": "0.0.2-1",
@@ -33782,33 +33783,32 @@
       }
     },
     "@empathyco/x-adapter": {
-      "version": "7.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-7.0.0-alpha.11.tgz",
-      "integrity": "sha512-Hf+AUNuIt8FOLlvfQrvGFq5SdCBfxGuP+5wHdkIJVofCHhCjEY8AMuqYlJQdgwgXuE+yBpO1VjvIVpKKe/yQzA==",
+      "version": "7.0.0-alpha.13",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-7.0.0-alpha.13.tgz",
+      "integrity": "sha512-8GOli9ES1U+PbhQKzy4kTxOH7x2uhzH2tx3sRVa7ISBw9yxNKInmWoMXAAq3h60+db6PuZIy5YczSj2TQaKPtw==",
       "requires": {
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.1",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.2",
         "@empathyco/x-get-safe-property-chain": "^1.3.0-alpha.1",
         "@empathyco/x-logger": "^1.1.0",
         "@empathyco/x-storage-service": "^2.0.0-alpha.0",
-        "@empathyco/x-types": "^10.0.0-alpha.15",
+        "@empathyco/x-types": "^10.0.0-alpha.17",
         "inversify": "~5.0.1",
         "reflect-metadata": "~0.1.13",
         "tslib": "~2.3.0"
       }
     },
     "@empathyco/x-components": {
-      "version": "3.0.0-alpha.55",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.55.tgz",
-      "integrity": "sha512-FtFC/oAVCcacpmvOOvWhFKk+0xoPKEQx+aXgJ1ddrGiP+a+izmejw4RUdzidfYHtJEpPm/xh18BMSGgRMbtH1A==",
+      "version": "3.0.0-alpha.63",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.63.tgz",
+      "integrity": "sha512-x1HUdk/wzllnceSo4cINnCBgtC6hO2dRtPbdHMlqloDTiobOlujsSmbTzy4n7yXVOH2+H5rHNDE2lNy7ZV1WnA==",
       "requires": {
-        "@empathyco/x-adapter": "^7.0.0-alpha.11",
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.1",
+        "@empathyco/x-adapter": "^7.0.0-alpha.13",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.2",
         "@empathyco/x-logger": "^1.2.0-alpha.1",
         "@empathyco/x-storage-service": "^2.0.0-alpha.0",
-        "@empathyco/x-types": "^10.0.0-alpha.15",
+        "@empathyco/x-types": "^10.0.0-alpha.17",
         "@types/resize-observer-browser": "~0.1.5",
-        "magic-string": "~0.25.7",
-        "nanoid": "~3.1.30",
+        "nanoid": "~3.1.31",
         "reflect-metadata": "~0.1.13",
         "rxjs": "~7.4.0",
         "tslib": "~2.3.0",
@@ -33831,9 +33831,9 @@
       }
     },
     "@empathyco/x-deep-merge": {
-      "version": "1.3.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-deep-merge/-/x-deep-merge-1.3.0-alpha.1.tgz",
-      "integrity": "sha512-tThLvh7pBVgohAr3nKdECpufUVjIbytg2oSjIelGmHVYWIDHLSOxHp9q0AbmJeOMMwMKXyEJl3PqjngklBt5Fg==",
+      "version": "1.3.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-deep-merge/-/x-deep-merge-1.3.0-alpha.2.tgz",
+      "integrity": "sha512-HrKe9OIuUf+Nh1V3HgxGUgEw+f1SS2Cr4/zRA4J4e1xhWNYA3xE+iGYmtlvZjjn+nE5RG29yoTobBjeW4xV4tA==",
       "requires": {
         "tslib": "~2.3.0"
       }
@@ -33890,9 +33890,9 @@
       }
     },
     "@empathyco/x-types": {
-      "version": "10.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.15.tgz",
-      "integrity": "sha512-kr8zyeLcmzsmk8pOl0vqfot2KYulPQXBBdrKm+i6GjxVJa0+JvnjlF5qatNCukRkddKwi3pQbtyupf3NNx7W/g==",
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-xm0zcVMBbZn7lSyaOVxwKL7sOykYxKwldrS4jXi4vYI7V8Hr0RjDnPLJKNAGuupYFvxwoMlpM0rF6Yyl95OSyg==",
       "requires": {
         "tslib": "~2.3.0"
       }
@@ -48345,6 +48345,7 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -53895,7 +53896,8 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spawn-command": {
       "version": "0.0.2-1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@empathyco/x-archetype",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@empathyco/x-archetype",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@empathyco/x-adapter": "^7.0.0-alpha.9",
@@ -70,8 +70,7 @@
         "source-map-loader": "~1.1.3",
         "start-server-and-test": "~1.14.0",
         "typescript": "~4.3.5",
-        "vue-template-compiler": "^2.6.0",
-        "wrapper-webpack-plugin": "~2.1.0"
+        "vue-template-compiler": "^2.6.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -31786,18 +31785,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/wrapper-webpack-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrapper-webpack-plugin/-/wrapper-webpack-plugin-2.1.0.tgz",
-      "integrity": "sha512-e+2FhSYGCxhDq3PcUw5mRhH+8vcYa+9d9AuLChJUZ9ZbUPhQOHZ/O2dnN98iTqeUuvrzSSOv13+x/NhrAm5JEg==",
-      "dev": true,
-      "dependencies": {
-        "webpack-sources": "^1.1.0"
-      },
-      "peerDependencies": {
-        "webpack": ">=2"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -57369,15 +57356,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
-      }
-    },
-    "wrapper-webpack-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrapper-webpack-plugin/-/wrapper-webpack-plugin-2.1.0.tgz",
-      "integrity": "sha512-e+2FhSYGCxhDq3PcUw5mRhH+8vcYa+9d9AuLChJUZ9ZbUPhQOHZ/O2dnN98iTqeUuvrzSSOv13+x/NhrAm5JEg==",
-      "dev": true,
-      "requires": {
-        "webpack-sources": "^1.1.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
     "source-map-loader": "~1.1.3",
     "start-server-and-test": "~1.14.0",
     "typescript": "~4.3.5",
-    "vue-template-compiler": "^2.6.0",
-    "wrapper-webpack-plugin": "~2.1.0"
+    "vue-template-compiler": "^2.6.0"
   },
   "prettier": "@empathyco/eslint-plugin-x/prettier-config",
   "gitHooks": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@empathyco/x-adapter": "^7.0.0-alpha.9",
-    "@empathyco/x-components": "^3.0.0-alpha.55",
+    "@empathyco/x-components": "^3.0.0-alpha.63",
     "@empathyco/x-types": "^10.0.0-alpha.14",
     "reflect-metadata": "^0.1.13",
     "tslib": "~2.3.0",

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -6,7 +6,6 @@ import {
   EmpathyRequestParamsMapper,
   EmpathySimpleFacetMapper
 } from '@empathyco/x-adapter';
-import { SnippetConfig } from '@empathyco/x-components';
 import { bannerMapper } from './demo-banner-mapper';
 import { HierarchicalFacetMapper } from './demo-hierarchical-mapper';
 import { promotedMapper } from './demo-promoted-mapper';
@@ -16,14 +15,7 @@ import { resultMapper } from './demo-result.mapper';
 import { priceFilterMapper } from './demo-price-filter-mapper';
 import { EmpathyEndpointsService } from './empathy-endpoints.service';
 
-declare global {
-  interface Window {
-    initX: SnippetConfig;
-  }
-}
-
 export const adapter = new EmpathyAdapterBuilder()
-  .setEnvironment(window.initX.env ?? 'test')
   .addMapper(resultMapper, 'results')
   .addMapper(bannerMapper, 'banners')
   .addMapper(promotedMapper, 'promoteds')

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,4 +5,4 @@ import { installXOptions } from './x-components/plugin.options';
 
 Vue.config.productionTip = false;
 
-new XInstaller(installXOptions);
+new XInstaller(installXOptions).init();

--- a/src/x-components/plugin.options.ts
+++ b/src/x-components/plugin.options.ts
@@ -10,6 +10,10 @@ export const installXOptions: InstallXOptions = {
   store,
   app: App,
   async installExtraPlugins({ vue, snippet }) {
+    // TODO: Remove this adapter configuration when the new stateless adapter is finished
+    adapter.setConfig({
+      env: snippet.env ?? 'test'
+    });
     const i18n = await I18n.create({
       locale: snippet.lang,
       device: snippet.device ?? 'mobile',

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,17 +1,3 @@
-const fs = require('fs');
-const WrapperPlugin = require('wrapper-webpack-plugin');
-
-const snippet = fs.readFileSync('./public/snippet-script.js', 'utf8');
-
-function init() {
-  if (typeof window.initX === 'function') {
-    const snippetOptions = window.initX();
-    window.X.init(snippetOptions);
-  } else if (typeof window.initX === 'object') {
-    window.X.init(window.initX);
-  }
-}
-
 module.exports = {
   transpileDependencies: ['@empathyco/x-components'],
   configureWebpack: {
@@ -23,13 +9,6 @@ module.exports = {
           use: ['source-map-loader']
         }
       ]
-    },
-    plugins: [
-      new WrapperPlugin({
-        test: /app\.js$/,
-        header: `(function(){${snippet}})();`,
-        footer: `(${init.toString()})()`
-      })
-    ]
+    }
   }
 };


### PR DESCRIPTION
EX-5423


Removes unnecessary `polyfills` support.
Removes `app.js` facade chunk, which only contained an import to the `x-core` chunk, and renamed the entry file from `app.js` to `x-core.js`.

## How has this been tested?

Install `x-components` locally building it from this [pull request](https://github.com/empathyco/x/pull/341), build the `x-archetype` and check that not `polyfills` are added in the `x-core` chunk.
