### PR TITLE
feat: add standard api adapter

### DIFF
--- a/src/adapter/standard-api-adapter.ts
+++ b/src/adapter/standard-api-adapter.ts
@@ -1,0 +1,67 @@
+import {
+  FacetsConfig,
+  facetsConfig,
+  numberFilterMutableSchema,
+  platformAdapter,
+  resultSchema
+} from '@empathyco/x-adapter-platform';
+import { Result } from '@empathyco/x-types';
+
+export const adapter = platformAdapter;
+
+/* Code sample about how to extend the result mapper with more fields. */
+
+interface EmpathyDemoPlatformResult {
+  __id: string;
+  __name: string;
+  __images: string[];
+  __url: string;
+  __externalId: string;
+  __prices: {
+    current: {
+      value: number;
+    };
+    previous?: {
+      value: number;
+    };
+  };
+  tagging: {
+    add2cart: string;
+    checkout: string;
+    click: string;
+  };
+}
+
+declare module '@empathyco/x-types' {
+  export interface Result {}
+}
+
+resultSchema.$override<EmpathyDemoPlatformResult, Partial<Result>>({
+  id: '__id',
+  name: '__name',
+  images: '__images',
+  url: '__url',
+  identifier: {
+    value: '__externalId'
+  },
+  price: {
+    value: '__prices.current.value',
+    originalValue: ({ __prices: rawPrices }) =>
+      rawPrices.previous?.value ?? rawPrices.current.value,
+    hasDiscount: ({ __prices: rawPrices }) =>
+      rawPrices.current.value < (rawPrices.previous?.value ?? rawPrices.current.value)
+  }
+});
+
+Object.assign<FacetsConfig, FacetsConfig>(facetsConfig, {
+  // TODO: Rename to currentPrice
+  '__prices.current.value': {
+    modelName: 'NumberRangeFacet',
+    schema: numberFilterMutableSchema
+  },
+  // TODO: Rename to previousPrice
+  '__prices.original.value': {
+    modelName: 'NumberRangeFacet',
+    schema: numberFilterMutableSchema
+  }
+});


### PR DESCRIPTION
EX-6423

Adds a standard API adapter. You can test this with the kenay instance:

```js
// snippet-config.js
var instance = getURLParameter('instance') || 'kenayhome';
var env = getEnv();
var scope = getURLParameter('scope') || 'desktop';
var lang = getURLParameter('lang') || 'es';
var device = getURLParameter('device') || 'mobile';
var searchLang = getURLParameter('searchLang') || lang;
var currency = getURLParameter('currency') || 'EUR';
var consent = getURLParameter('consent') !== 'false';
var documentDirection = getURLParameter('doc-dir') || 'ltr';
```

```ts
import { adapter } from '../adapter/standard-api-adapter';
```

If you want translations for the facets you can use:

```ts
// messages.types.ts
  facets: {
    currentPrice: string;
    previousPrice: string;
    condition: string;
    color: string;
    height: string;
    depth: string;
    width: string;
    category: string;
    material: string;
    legsMaterial: string;
    basic: string;
  };
```

```json
  // es.messages.json
    "facets": {
      "currentPrice": "Precio actual",
      "previousPrice": "Precio original",
      "condition": "Condición",
      "color": "Color",
      "height": "Altura",
      "depth": "Fondo",
      "width": "Anchura",
      "category": "Categoría",
      "material": "Material",
      "legsMaterial": "Material de las patas",
      "basic": "Básico"
    },
```

```json
// en.messages.json
    "facets": {
      "currentPrice": "Current price",
      "previousPrice": "Original price",
      "condition": "Condition",
      "color": "Color",
      "height": "Height",
      "depth": "Depth",
      "width": "Width",
      "category": "Category",
      "material": "Material",
      "legsMaterial": "Legs material",
      "basic": "Basic"
    },
```