### PR TITLE
fix: wrap on long words in the no results message

### DIFF
--- a/src/components/search/no-results-message.vue
+++ b/src/components/search/no-results-message.vue
@@ -2,7 +2,7 @@
   <span
     v-if="$x.noResults"
     v-html="$t('noResults.message', { query: $x.query.search })"
-    class="x-message x-text"
+    class="x-no-results-message x-message x-text"
     :class="{ 'x-font-size--05': $x.device === 'desktop' }"
   />
 </template>
@@ -13,3 +13,15 @@
   @Component
   export default class NoResultsMessage extends Vue {}
 </script>
+
+<style lang="scss">
+  .x-no-results-message {
+    > span {
+      width: 100%;
+
+      .x-text {
+        word-wrap: break-word;
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
[EX-6537](https://searchbroker.atlassian.net/browse/EX-6537)

## Motivation and context

When searching for long, single-word queries the message in the `no-results-message` component didn't wrap. This made the mobile view look really bad. This PR makes it so it would break long words and wrap.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

Search for a query by smashing your keyboard a couple of times and see how the `no-results-message` looks.
