### PR TITLE
feat: add `NextQueryPreview` carousel in results grid

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -9,5 +9,6 @@
   "screenshotOnRunFailure": false,
   "video": false,
   "testFiles": "**/*.feature",
-  "retries": 1
+  "retries": 1,
+  "ignoreTestFiles": ["**/scroll.feature"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.3",
-        "@empathyco/x-adapter-platform": "^1.0.0-alpha.25",
-        "@empathyco/x-components": "^3.0.0-alpha.150",
+        "@empathyco/x-adapter": "^8.0.0-alpha.4",
+        "@empathyco/x-adapter-platform": "^1.0.0-alpha.29",
+        "@empathyco/x-components": "^3.0.0-alpha.151",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
-        "@empathyco/x-types": "^10.0.0-alpha.27",
+        "@empathyco/x-types": "^10.0.0-alpha.30",
         "@empathyco/x-utils": "^1.0.0-alpha.5",
         "tslib": "~2.3.0",
         "vue": "~2.6.14",
@@ -25,8 +25,8 @@
       },
       "devDependencies": {
         "@cypress/webpack-preprocessor": "~5.11.1",
-        "@empathyco/eslint-plugin-x": "^2.0.0-alpha.10",
-        "@empathyco/x-translations": "^1.1.0-alpha.22",
+        "@empathyco/eslint-plugin-x": "^2.0.0-alpha.11",
+        "@empathyco/x-translations": "^1.1.0-alpha.23",
         "@rollup/plugin-commonjs": "~21.0.1",
         "@rollup/plugin-json": "~4.1.0",
         "@rollup/plugin-node-resolve": "~13.1.3",
@@ -2000,9 +2000,9 @@
       }
     },
     "node_modules/@empathyco/eslint-plugin-x": {
-      "version": "2.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@empathyco/eslint-plugin-x/-/eslint-plugin-x-2.0.0-alpha.10.tgz",
-      "integrity": "sha512-BQ4egRruADMus35ySu7iWIpfgmhiVq7W3lB6Er95tAJrluxNn3o1zU7Iods+oZAXOrNuN7OHhGrZk4tXD41PxA==",
+      "version": "2.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@empathyco/eslint-plugin-x/-/eslint-plugin-x-2.0.0-alpha.11.tgz",
+      "integrity": "sha512-L7Nzy9e0HrRvadla5jNl/Que+R7eY3iQ31OR3j3TET2+2aX86w3kKfRzsE4w93DjWS3tP4rr+DpMCgjqOf19Ag==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "~5.21.0",
@@ -2301,20 +2301,20 @@
       }
     },
     "node_modules/@empathyco/x-adapter-platform": {
-      "version": "1.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter-platform/-/x-adapter-platform-1.0.0-alpha.25.tgz",
-      "integrity": "sha512-ZfKzFVvkDTp01rZ+JYm0g4oxhl4KPOc1lNHnMj1L9JqfQKJ+vgJtZjFNE3dKQLhDV0HAw3vNniiD7Q5rKTN47Q==",
+      "version": "1.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter-platform/-/x-adapter-platform-1.0.0-alpha.29.tgz",
+      "integrity": "sha512-gr0Q1d7d3/1rcX+4VflA5zJhNeWCNudlUhgMDjY8RkwW4swWto+v8FUGwuMbx+KcwpjEVg/mFv2GZtz4gNHibQ==",
       "dependencies": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.3",
-        "@empathyco/x-types": "^10.0.0-alpha.27",
+        "@empathyco/x-adapter": "^8.0.0-alpha.4",
+        "@empathyco/x-types": "^10.0.0-alpha.30",
         "@empathyco/x-utils": "^1.0.0-alpha.5",
         "tslib": "~2.3.0"
       }
     },
     "node_modules/@empathyco/x-components": {
-      "version": "3.0.0-alpha.150",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.150.tgz",
-      "integrity": "sha512-jagpu6Zk6Ok8eGWqsBQjXQwk0rtGKL6XVKY38BzKte5fMJe9gzSkz7p9KDeUqZBwbdrFIRg2b2KeR/4WwgQMSA==",
+      "version": "3.0.0-alpha.151",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.151.tgz",
+      "integrity": "sha512-5qWY2wW8GPX7uJEtG8JP/xXRevgyZDxlP+nxcMHJbTIRtwgqXfTEkobzdu/3YLJThTgWtBaT5QvZ/aQlYbQlRw==",
       "dependencies": {
         "@empathyco/x-adapter": "^8.0.0-alpha.4",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/@empathyco/x-translations": {
-      "version": "1.1.0-alpha.22",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-translations/-/x-translations-1.1.0-alpha.22.tgz",
-      "integrity": "sha512-fDdJAZK/cJSIEkN3P5XHH0HZzmfLmuY2jyUk3W/JEIMk3hJyo4wjcBUr230QQgXEX9l/qHsEzak6MfuBbCm80A==",
+      "version": "1.1.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-translations/-/x-translations-1.1.0-alpha.23.tgz",
+      "integrity": "sha512-RctTn4X8t8VZLW/jrqPsu1XQLfDJaacwontdEouK5jgXc/ANmxu8sHvEYHXimcyTZrv845btaGZz6t/6v6LOFA==",
       "dev": true,
       "dependencies": {
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19"
@@ -28486,9 +28486,9 @@
       }
     },
     "@empathyco/eslint-plugin-x": {
-      "version": "2.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@empathyco/eslint-plugin-x/-/eslint-plugin-x-2.0.0-alpha.10.tgz",
-      "integrity": "sha512-BQ4egRruADMus35ySu7iWIpfgmhiVq7W3lB6Er95tAJrluxNn3o1zU7Iods+oZAXOrNuN7OHhGrZk4tXD41PxA==",
+      "version": "2.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@empathyco/eslint-plugin-x/-/eslint-plugin-x-2.0.0-alpha.11.tgz",
+      "integrity": "sha512-L7Nzy9e0HrRvadla5jNl/Que+R7eY3iQ31OR3j3TET2+2aX86w3kKfRzsE4w93DjWS3tP4rr+DpMCgjqOf19Ag==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "~5.21.0",
@@ -28710,20 +28710,20 @@
       }
     },
     "@empathyco/x-adapter-platform": {
-      "version": "1.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter-platform/-/x-adapter-platform-1.0.0-alpha.25.tgz",
-      "integrity": "sha512-ZfKzFVvkDTp01rZ+JYm0g4oxhl4KPOc1lNHnMj1L9JqfQKJ+vgJtZjFNE3dKQLhDV0HAw3vNniiD7Q5rKTN47Q==",
+      "version": "1.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter-platform/-/x-adapter-platform-1.0.0-alpha.29.tgz",
+      "integrity": "sha512-gr0Q1d7d3/1rcX+4VflA5zJhNeWCNudlUhgMDjY8RkwW4swWto+v8FUGwuMbx+KcwpjEVg/mFv2GZtz4gNHibQ==",
       "requires": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.3",
-        "@empathyco/x-types": "^10.0.0-alpha.27",
+        "@empathyco/x-adapter": "^8.0.0-alpha.4",
+        "@empathyco/x-types": "^10.0.0-alpha.30",
         "@empathyco/x-utils": "^1.0.0-alpha.5",
         "tslib": "~2.3.0"
       }
     },
     "@empathyco/x-components": {
-      "version": "3.0.0-alpha.150",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.150.tgz",
-      "integrity": "sha512-jagpu6Zk6Ok8eGWqsBQjXQwk0rtGKL6XVKY38BzKte5fMJe9gzSkz7p9KDeUqZBwbdrFIRg2b2KeR/4WwgQMSA==",
+      "version": "3.0.0-alpha.151",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.151.tgz",
+      "integrity": "sha512-5qWY2wW8GPX7uJEtG8JP/xXRevgyZDxlP+nxcMHJbTIRtwgqXfTEkobzdu/3YLJThTgWtBaT5QvZ/aQlYbQlRw==",
       "requires": {
         "@empathyco/x-adapter": "^8.0.0-alpha.4",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
@@ -28789,9 +28789,9 @@
       }
     },
     "@empathyco/x-translations": {
-      "version": "1.1.0-alpha.22",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-translations/-/x-translations-1.1.0-alpha.22.tgz",
-      "integrity": "sha512-fDdJAZK/cJSIEkN3P5XHH0HZzmfLmuY2jyUk3W/JEIMk3hJyo4wjcBUr230QQgXEX9l/qHsEzak6MfuBbCm80A==",
+      "version": "1.1.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-translations/-/x-translations-1.1.0-alpha.23.tgz",
+      "integrity": "sha512-RctTn4X8t8VZLW/jrqPsu1XQLfDJaacwontdEouK5jgXc/ANmxu8sHvEYHXimcyTZrv845btaGZz6t/6v6LOFA==",
       "dev": true,
       "requires": {
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@empathyco/x-adapter": "^8.0.0-alpha.3",
         "@empathyco/x-adapter-platform": "^1.0.0-alpha.25",
-        "@empathyco/x-components": "^3.0.0-alpha.137",
+        "@empathyco/x-components": "^3.0.0-alpha.150",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
         "@empathyco/x-types": "^10.0.0-alpha.27",
         "@empathyco/x-utils": "^1.0.0-alpha.5",
@@ -2291,9 +2291,9 @@
       }
     },
     "node_modules/@empathyco/x-adapter": {
-      "version": "8.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.3.tgz",
-      "integrity": "sha512-JIy+i6c2aRb5Kie9MABxO5fVXDBFM2Y1YflrYyiX93qUMulSuv4ILZykX2EEXQliNU/9C5gMco6I9pxauYyE+w==",
+      "version": "8.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.4.tgz",
+      "integrity": "sha512-RCs/ONN8z554WJAemuZMHIRtydYKyj6P5ajywCmKaoOkEFU4BzPXKu+RUDpLZT1iCJRwo/95lzzdjI8EvKG5DA==",
       "dependencies": {
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
         "@empathyco/x-get-safe-property-chain": "^1.3.0-alpha.3",
@@ -2312,15 +2312,15 @@
       }
     },
     "node_modules/@empathyco/x-components": {
-      "version": "3.0.0-alpha.137",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.137.tgz",
-      "integrity": "sha512-ZDQWgTfZf8/Wpirwd1nxY6iGF+LVDSyrqQMwS5CYdvdaWM7W0KEHVCX/jR3Cw02UNIX2e2GehKs1cjMXg9fQuA==",
+      "version": "3.0.0-alpha.150",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.150.tgz",
+      "integrity": "sha512-jagpu6Zk6Ok8eGWqsBQjXQwk0rtGKL6XVKY38BzKte5fMJe9gzSkz7p9KDeUqZBwbdrFIRg2b2KeR/4WwgQMSA==",
       "dependencies": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.3",
+        "@empathyco/x-adapter": "^8.0.0-alpha.4",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
         "@empathyco/x-logger": "^1.2.0-alpha.3",
         "@empathyco/x-storage-service": "^2.0.0-alpha.2",
-        "@empathyco/x-types": "^10.0.0-alpha.27",
+        "@empathyco/x-types": "^10.0.0-alpha.30",
         "@empathyco/x-utils": "^1.0.0-alpha.5",
         "@types/resize-observer-browser": "~0.1.5",
         "rxjs": "~7.4.0",
@@ -2395,11 +2395,11 @@
       }
     },
     "node_modules/@empathyco/x-types": {
-      "version": "10.0.0-alpha.27",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.27.tgz",
-      "integrity": "sha512-ax8P11KUoe6hBmYHXsKXNftF1aUAPOinWtERRKcgvCqr1Aq6IOsY/tzMXtjSmexr47SCRpjtRmP66L5Al1e1Fw==",
+      "version": "10.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.30.tgz",
+      "integrity": "sha512-XqTSL9xo2wYU0gQRab3lu8WVwhHiYrziLyvfgwAcSiXN3ZR5UGCAS7ikX6vGvj9S6QT6VDtsM2WM8NgnODQ8XQ==",
       "dependencies": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.3",
+        "@empathyco/x-adapter": "^8.0.0-alpha.4",
         "tslib": "~2.3.0"
       },
       "engines": {
@@ -28700,9 +28700,9 @@
       }
     },
     "@empathyco/x-adapter": {
-      "version": "8.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.3.tgz",
-      "integrity": "sha512-JIy+i6c2aRb5Kie9MABxO5fVXDBFM2Y1YflrYyiX93qUMulSuv4ILZykX2EEXQliNU/9C5gMco6I9pxauYyE+w==",
+      "version": "8.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.4.tgz",
+      "integrity": "sha512-RCs/ONN8z554WJAemuZMHIRtydYKyj6P5ajywCmKaoOkEFU4BzPXKu+RUDpLZT1iCJRwo/95lzzdjI8EvKG5DA==",
       "requires": {
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
         "@empathyco/x-get-safe-property-chain": "^1.3.0-alpha.3",
@@ -28721,15 +28721,15 @@
       }
     },
     "@empathyco/x-components": {
-      "version": "3.0.0-alpha.137",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.137.tgz",
-      "integrity": "sha512-ZDQWgTfZf8/Wpirwd1nxY6iGF+LVDSyrqQMwS5CYdvdaWM7W0KEHVCX/jR3Cw02UNIX2e2GehKs1cjMXg9fQuA==",
+      "version": "3.0.0-alpha.150",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.150.tgz",
+      "integrity": "sha512-jagpu6Zk6Ok8eGWqsBQjXQwk0rtGKL6XVKY38BzKte5fMJe9gzSkz7p9KDeUqZBwbdrFIRg2b2KeR/4WwgQMSA==",
       "requires": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.3",
+        "@empathyco/x-adapter": "^8.0.0-alpha.4",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
         "@empathyco/x-logger": "^1.2.0-alpha.3",
         "@empathyco/x-storage-service": "^2.0.0-alpha.2",
-        "@empathyco/x-types": "^10.0.0-alpha.27",
+        "@empathyco/x-types": "^10.0.0-alpha.30",
         "@empathyco/x-utils": "^1.0.0-alpha.5",
         "@types/resize-observer-browser": "~0.1.5",
         "rxjs": "~7.4.0",
@@ -28798,11 +28798,11 @@
       }
     },
     "@empathyco/x-types": {
-      "version": "10.0.0-alpha.27",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.27.tgz",
-      "integrity": "sha512-ax8P11KUoe6hBmYHXsKXNftF1aUAPOinWtERRKcgvCqr1Aq6IOsY/tzMXtjSmexr47SCRpjtRmP66L5Al1e1Fw==",
+      "version": "10.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.30.tgz",
+      "integrity": "sha512-XqTSL9xo2wYU0gQRab3lu8WVwhHiYrziLyvfgwAcSiXN3ZR5UGCAS7ikX6vGvj9S6QT6VDtsM2WM8NgnODQ8XQ==",
       "requires": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.3",
+        "@empathyco/x-adapter": "^8.0.0-alpha.4",
         "tslib": "~2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "csv:json": "csv-json ./output ./src/i18n/messages"
   },
   "dependencies": {
-    "@empathyco/x-adapter": "^8.0.0-alpha.3",
-    "@empathyco/x-components": "^3.0.0-alpha.150",
-    "@empathyco/x-adapter-platform": "^1.0.0-alpha.25",
+    "@empathyco/x-adapter": "^8.0.0-alpha.4",
+    "@empathyco/x-components": "^3.0.0-alpha.151",
+    "@empathyco/x-adapter-platform": "^1.0.0-alpha.29",
     "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
-    "@empathyco/x-types": "^10.0.0-alpha.27",
+    "@empathyco/x-types": "^10.0.0-alpha.30",
     "@empathyco/x-utils": "^1.0.0-alpha.5",
     "tslib": "~2.3.0",
     "vue": "~2.6.14",
@@ -40,8 +40,8 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "~5.11.1",
-    "@empathyco/eslint-plugin-x": "^2.0.0-alpha.10",
-    "@empathyco/x-translations": "^1.1.0-alpha.22",
+    "@empathyco/eslint-plugin-x": "^2.0.0-alpha.11",
+    "@empathyco/x-translations": "^1.1.0-alpha.23",
     "@rollup/plugin-commonjs": "~21.0.1",
     "@rollup/plugin-json": "~4.1.0",
     "@rollup/plugin-node-resolve": "~13.1.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@empathyco/x-adapter": "^8.0.0-alpha.3",
-    "@empathyco/x-components": "^3.0.0-alpha.137",
+    "@empathyco/x-components": "^3.0.0-alpha.150",
     "@empathyco/x-adapter-platform": "^1.0.0-alpha.25",
     "@empathyco/x-deep-merge": "^1.3.0-alpha.19",
     "@empathyco/x-types": "^10.0.0-alpha.27",

--- a/src/components/desktop/desktop-next-query-preview.vue
+++ b/src/components/desktop/desktop-next-query-preview.vue
@@ -24,7 +24,7 @@
     <BaseGrid
       #default="{ item }"
       :animation="gridAnimation"
-      :columns="4"
+      :columns="maxItemsToRender"
       :items="results.slice(0, maxItemsToRender)"
       class="x-padding--00"
     >

--- a/src/components/desktop/desktop-next-query-preview.vue
+++ b/src/components/desktop/desktop-next-query-preview.vue
@@ -62,7 +62,7 @@
       Result
     }
   })
-  export default class CustomNextQueryPreview extends Vue {
+  export default class DesktopNextQueryPreview extends Vue {
     @Prop({ default: 4 })
     protected maxItemsToRender!: number;
 

--- a/src/components/desktop/desktop-next-query-preview.vue
+++ b/src/components/desktop/desktop-next-query-preview.vue
@@ -21,18 +21,17 @@
         }}
       </span>
     </div>
-    <div class="x-list x-list--horizontal x-list--justify-space-between x-list--gap-05">
-      <Result
-        v-for="result in results.slice(0, maxItemsToRender)"
-        :key="result.id"
-        :result="result"
-        :showAddToCart="false"
-        class="x-next-query-preview__result"
-      />
-    </div>
-    <BaseEventButton
-      v-if="$x.device === 'desktop'"
-      :events="clickEvents"
+    <BaseGrid
+      #default="{ item }"
+      :animation="gridAnimation"
+      :columns="4"
+      :items="results.slice(0, maxItemsToRender)"
+      class="x-padding--00"
+    >
+      <Result :result="item" />
+    </BaseGrid>
+    <NextQuery
+      :suggestion="nextQuery"
       class="
         x-tag x-tag--pill
         x-font-weight--bold
@@ -40,38 +39,37 @@
         x-padding--top-04 x-padding--bottom-04 x-padding--right-05 x-padding--left-05
         x-font-color--lead
         x-border-color--lead
-        x-background--neutral-100
       "
     >
       {{ $t('nextQueryPreview.viewResults', { totalResults }) }}
-    </BaseEventButton>
+    </NextQuery>
   </NextQueryPreview>
 </template>
 
 <script lang="ts">
   import { Component, Prop, Vue } from 'vue-property-decorator';
-  import { BaseEventButton, XEventsTypes } from '@empathyco/x-components';
-  import { NextQueryPreview } from '@empathyco/x-components/next-queries';
-  import { NextQuery } from '@empathyco/x-types';
+  import { BaseGrid, StaggeredFadeAndSlide } from '@empathyco/x-components';
+  import { NextQuery, NextQueryPreview } from '@empathyco/x-components/next-queries';
+  import { NextQuery as NextQueryModel } from '@empathyco/x-types';
   import Result from '../results/result.vue';
 
   @Component({
     components: {
-      BaseEventButton,
+      BaseGrid,
+      NextQuery,
       NextQueryPreview,
       Result
     }
   })
   export default class DesktopNextQueryPreview extends Vue {
+    // TODO: Remove this and configure NextQueryPreview after doing EX-6819.
     @Prop({ default: 4 })
     protected maxItemsToRender!: number;
 
     @Prop({ required: true })
-    protected nextQuery!: NextQuery;
+    protected nextQuery!: NextQueryModel;
 
-    protected clickEvents: Partial<XEventsTypes> = {
-      UserAcceptedAQuery: this.nextQuery.query
-    };
+    protected gridAnimation = StaggeredFadeAndSlide;
   }
 </script>
 
@@ -79,11 +77,5 @@
   .x-base-grid__next-queries-group {
     grid-column-start: 1;
     grid-column-end: -1;
-  }
-
-  .x-desktop {
-    .x-next-query-preview__result {
-      max-width: calc(25% - var(--x-size-gap-list-05));
-    }
   }
 </style>

--- a/src/components/desktop/desktop-next-query-preview.vue
+++ b/src/components/desktop/desktop-next-query-preview.vue
@@ -23,7 +23,6 @@
     </div>
     <BaseGrid
       #default="{ item }"
-      :animation="gridAnimation"
       :columns="maxItemsToRender"
       :items="results.slice(0, maxItemsToRender)"
       class="x-padding--00"
@@ -48,7 +47,7 @@
 
 <script lang="ts">
   import { Component, Prop, Vue } from 'vue-property-decorator';
-  import { BaseGrid, StaggeredFadeAndSlide } from '@empathyco/x-components';
+  import { BaseGrid } from '@empathyco/x-components';
   import { NextQuery, NextQueryPreview } from '@empathyco/x-components/next-queries';
   import { NextQuery as NextQueryModel } from '@empathyco/x-types';
   import Result from '../results/result.vue';
@@ -68,14 +67,5 @@
 
     @Prop({ required: true })
     protected nextQuery!: NextQueryModel;
-
-    protected gridAnimation = StaggeredFadeAndSlide;
   }
 </script>
-
-<style lang="scss">
-  .x-base-grid__next-queries-group {
-    grid-column-start: 1;
-    grid-column-end: -1;
-  }
-</style>

--- a/src/components/desktop/desktop-next-query-preview.vue
+++ b/src/components/desktop/desktop-next-query-preview.vue
@@ -1,0 +1,89 @@
+<template>
+  <NextQueryPreview
+    #default="{ results, totalResults, suggestion }"
+    class="x-list x-background--neutral-95 x-list--gap-06 x-padding--06"
+    :suggestion="nextQuery"
+  >
+    <span class="x-title2 x-font-weight--bold">{{ $t('nextQueryPreview.title') }}</span>
+    <div class="x-list x-list--horizontal x-list--align-center x-list--gap-03">
+      <span class="x-title3 x-font-weight--bold">
+        {{
+          $t('nextQueryPreview.query', {
+            query: suggestion.query
+          })
+        }}
+      </span>
+      <span class="x-text">
+        {{
+          $t('nextQueryPreview.totalResults', {
+            totalResults: totalResults
+          })
+        }}
+      </span>
+    </div>
+    <div class="x-list x-list--horizontal x-list--justify-space-between x-list--gap-05">
+      <Result
+        v-for="result in results.slice(0, maxItemsToRender)"
+        :key="result.id"
+        :result="result"
+        :showAddToCart="false"
+        class="x-next-query-preview__result"
+      />
+    </div>
+    <BaseEventButton
+      v-if="$x.device === 'desktop'"
+      :events="clickEvents"
+      class="
+        x-tag x-tag--pill
+        x-font-weight--bold
+        x-margin--left-auto x-margin--right-auto
+        x-padding--top-04 x-padding--bottom-04 x-padding--right-05 x-padding--left-05
+        x-font-color--lead
+        x-border-color--lead
+        x-background--neutral-100
+      "
+    >
+      {{ $t('nextQueryPreview.viewResults', { totalResults }) }}
+    </BaseEventButton>
+  </NextQueryPreview>
+</template>
+
+<script lang="ts">
+  import { Component, Prop, Vue } from 'vue-property-decorator';
+  import { BaseEventButton, XEventsTypes } from '@empathyco/x-components';
+  import { NextQueryPreview } from '@empathyco/x-components/next-queries';
+  import { NextQuery } from '@empathyco/x-types';
+  import Result from '../results/result.vue';
+
+  @Component({
+    components: {
+      BaseEventButton,
+      NextQueryPreview,
+      Result
+    }
+  })
+  export default class CustomNextQueryPreview extends Vue {
+    @Prop({ default: 4 })
+    protected maxItemsToRender!: number;
+
+    @Prop({ required: true })
+    protected nextQuery!: NextQuery;
+
+    protected clickEvents: Partial<XEventsTypes> = {
+      UserAcceptedAQuery: this.nextQuery.query
+    };
+  }
+</script>
+
+<style lang="scss">
+  .x-base-grid__next-queries-group {
+    grid-column-start: 1;
+    grid-column-end: -1;
+  }
+
+  .x-desktop {
+    .x-next-query-preview__result {
+      max-width: calc(25% - var(--x-size-gap-list-05));
+    }
+  }
+</style>

--- a/src/components/mobile/mobile-next-query-preview.vue
+++ b/src/components/mobile/mobile-next-query-preview.vue
@@ -10,8 +10,8 @@
     :suggestion="nextQuery"
   >
     <span class="x-title2 x-font-weight--bold">{{ $t('nextQueryPreview.title') }}</span>
-    <div class="x-list x-list--horizontal x-list--align-center x-list--justify-space-between">
-      <div class="x-list x-list--horizontal x-list--align-center x-list--gap-02">
+    <div class="x-list x-list--horizontal x-list--align-center">
+      <div class="x-list x-list--horizontal x-list--align-baseline x-list--gap-02">
         <span class="x-title3 x-font-weight--bold">
           {{
             $t('nextQueryPreview.query', {
@@ -29,7 +29,7 @@
       </div>
       <NextQuery
         :suggestion="nextQuery"
-        class="x-button x-button--ghost x-border-width--00 x-padding--00 x-font-weight--bold"
+        class="x-button x-button--ghost x-padding--00 x-margin--left-auto x-font-weight--bold"
       >
         {{ $t('nextQueryPreview.viewResults') }}
       </NextQuery>
@@ -75,15 +75,14 @@
 <style lang="scss">
   .x-mobile {
     .x-next-query-preview {
-      margin-right: calc(-1 * var(--x-size-padding-grid));
-      margin-left: calc(-1 * var(--x-size-padding-grid));
+      margin-inline: calc(-1 * var(--x-size-padding-grid));
 
       &__result {
-        max-width: calc(38vw - var(--x-size-gap-list-05));
+        width: calc(38vw - var(--x-size-gap-list-05));
       }
 
       .x-sliding-panel {
-        margin-right: calc(-1 * var(--x-size-padding-grid));
+        margin-inline-end: calc(-1 * var(--x-size-padding-grid));
       }
     }
   }

--- a/src/components/mobile/mobile-next-query-preview.vue
+++ b/src/components/mobile/mobile-next-query-preview.vue
@@ -81,10 +81,10 @@
       &__result {
         max-width: calc(38vw - var(--x-size-gap-list-05));
       }
-    }
 
-    .x-margin--right-negative {
-      margin-right: calc(-1 * var(--x-size-padding-grid));
+      .x-margin--right-negative {
+        margin-right: calc(-1 * var(--x-size-padding-grid));
+      }
     }
   }
 </style>

--- a/src/components/mobile/mobile-next-query-preview.vue
+++ b/src/components/mobile/mobile-next-query-preview.vue
@@ -67,7 +67,7 @@
       SlidingPanel
     }
   })
-  export default class CustomNextQueryPreview extends Vue {
+  export default class MobileNextQueryPreview extends Vue {
     @Prop({ required: true })
     protected nextQuery!: NextQuery;
 

--- a/src/components/mobile/mobile-next-query-preview.vue
+++ b/src/components/mobile/mobile-next-query-preview.vue
@@ -1,0 +1,95 @@
+<template>
+  <NextQueryPreview
+    #default="{ results, totalResults, suggestion }"
+    class="
+      x-list x-list--gap-05
+      x-background--neutral-95
+      x-padding--06 x-padding--bottom-06
+      x-margin--top-10 x-margin--bottom-05
+    "
+    :suggestion="nextQuery"
+  >
+    <span class="x-title2 x-font-weight--bold">{{ $t('nextQueryPreview.title') }}</span>
+    <div class="x-list x-list--horizontal x-list--align-center x-list--justify-space-between">
+      <div class="x-list x-list--horizontal x-list--align-center x-list--gap-02">
+        <span class="x-title3 x-font-weight--bold">
+          {{
+            $t('nextQueryPreview.query', {
+              query: suggestion.query
+            })
+          }}
+        </span>
+        <span class="x-text x-font-size--04">
+          {{
+            $t('nextQueryPreview.totalResults', {
+              totalResults: totalResults
+            })
+          }}
+        </span>
+      </div>
+      <BaseEventButton
+        :events="clickEvents"
+        class="x-button x-button--ghost x-border-width--00 x-padding--right-00"
+      >
+        {{ $t('nextQueryPreview.viewResults') }}
+      </BaseEventButton>
+    </div>
+    <SlidingPanel
+      class="x-sliding-panel--no-gradient x-background--neutral-95 x-margin--right-negative"
+      :showButtons="false"
+      :resetOnContentChange="false"
+    >
+      <div class="x-list x-list--gap-05">
+        <Result
+          v-for="result in results"
+          :key="result.id"
+          :result="result"
+          :showAddToCart="false"
+          class="x-next-query-preview__result"
+        />
+      </div>
+    </SlidingPanel>
+  </NextQueryPreview>
+</template>
+
+<script lang="ts">
+  import { Component, Prop, Vue } from 'vue-property-decorator';
+  import { BaseEventButton, SlidingPanel, XEventsTypes } from '@empathyco/x-components';
+  import { NextQueryPreview } from '@empathyco/x-components/next-queries';
+  import { NextQuery } from '@empathyco/x-types';
+  import Result from '../results/result.vue';
+
+  @Component({
+    components: {
+      BaseEventButton,
+      NextQueryPreview,
+      Result,
+      SlidingPanel
+    }
+  })
+  export default class CustomNextQueryPreview extends Vue {
+    @Prop({ required: true })
+    protected nextQuery!: NextQuery;
+
+    protected clickEvents: Partial<XEventsTypes> = {
+      UserAcceptedAQuery: this.nextQuery.query
+    };
+  }
+</script>
+
+<style lang="scss">
+  .x-mobile {
+    .x-next-query-preview {
+      margin-right: calc(-1 * var(--x-size-padding-grid));
+      margin-left: calc(-1 * var(--x-size-padding-grid));
+
+      &__result {
+        max-width: calc(38vw - var(--x-size-gap-list-05));
+      }
+    }
+
+    .x-margin--right-negative {
+      margin-right: calc(-1 * var(--x-size-padding-grid));
+    }
+  }
+</style>

--- a/src/components/mobile/mobile-next-query-preview.vue
+++ b/src/components/mobile/mobile-next-query-preview.vue
@@ -4,13 +4,15 @@
     class="
       x-list x-list--gap-05
       x-background--neutral-95
-      x-padding--06 x-padding--bottom-06
+      x-padding--top-06 x-padding--bottom-06
       x-margin--top-10 x-margin--bottom-05
     "
     :suggestion="nextQuery"
   >
-    <span class="x-title2 x-font-weight--bold">{{ $t('nextQueryPreview.title') }}</span>
-    <div class="x-list x-list--horizontal x-list--align-center">
+    <span class="x-next-query-preview__title x-title2 x-font-weight--bold">
+      {{ $t('nextQueryPreview.title') }}
+    </span>
+    <div class="x-next-query-preview__header x-list x-list--horizontal x-list--align-center">
       <div class="x-list x-list--horizontal x-list--align-baseline x-list--gap-02">
         <span class="x-title3 x-font-weight--bold">
           {{
@@ -77,12 +79,20 @@
     .x-next-query-preview {
       margin-inline: calc(-1 * var(--x-size-padding-grid));
 
+      &__title {
+        padding-inline: var(--x-size-padding-grid);
+      }
+
+      &__header {
+        padding-inline: var(--x-size-padding-grid);
+      }
+
       &__result {
         width: calc(38vw - var(--x-size-gap-list-05));
       }
 
-      .x-sliding-panel {
-        margin-inline-end: calc(-1 * var(--x-size-padding-grid));
+      .x-sliding-panel__scroll {
+        padding-left: var(--x-size-padding-grid);
       }
     }
   }

--- a/src/components/mobile/mobile-next-query-preview.vue
+++ b/src/components/mobile/mobile-next-query-preview.vue
@@ -27,15 +27,15 @@
           }}
         </span>
       </div>
-      <BaseEventButton
-        :events="clickEvents"
-        class="x-button x-button--ghost x-border-width--00 x-padding--right-00"
+      <NextQuery
+        :suggestion="nextQuery"
+        class="x-button x-button--ghost x-border-width--00 x-padding--00 x-font-weight--bold"
       >
         {{ $t('nextQueryPreview.viewResults') }}
-      </BaseEventButton>
+      </NextQuery>
     </div>
     <SlidingPanel
-      class="x-sliding-panel--no-gradient x-background--neutral-95 x-margin--right-negative"
+      class="x-background--neutral-95 x-margin--right-negative"
       :showButtons="false"
       :resetOnContentChange="false"
     >
@@ -44,7 +44,6 @@
           v-for="result in results"
           :key="result.id"
           :result="result"
-          :showAddToCart="false"
           class="x-next-query-preview__result"
         />
       </div>
@@ -54,14 +53,14 @@
 
 <script lang="ts">
   import { Component, Prop, Vue } from 'vue-property-decorator';
-  import { BaseEventButton, SlidingPanel, XEventsTypes } from '@empathyco/x-components';
-  import { NextQueryPreview } from '@empathyco/x-components/next-queries';
-  import { NextQuery } from '@empathyco/x-types';
+  import { SlidingPanel } from '@empathyco/x-components';
+  import { NextQuery, NextQueryPreview } from '@empathyco/x-components/next-queries';
+  import { NextQuery as NextQueryModel } from '@empathyco/x-types';
   import Result from '../results/result.vue';
 
   @Component({
     components: {
-      BaseEventButton,
+      NextQuery,
       NextQueryPreview,
       Result,
       SlidingPanel
@@ -69,11 +68,7 @@
   })
   export default class MobileNextQueryPreview extends Vue {
     @Prop({ required: true })
-    protected nextQuery!: NextQuery;
-
-    protected clickEvents: Partial<XEventsTypes> = {
-      UserAcceptedAQuery: this.nextQuery.query
-    };
+    protected nextQuery!: NextQueryModel;
   }
 </script>
 

--- a/src/components/mobile/mobile-next-query-preview.vue
+++ b/src/components/mobile/mobile-next-query-preview.vue
@@ -35,7 +35,7 @@
       </NextQuery>
     </div>
     <SlidingPanel
-      class="x-background--neutral-95 x-margin--right-negative"
+      class="x-background--neutral-95"
       :showButtons="false"
       :resetOnContentChange="false"
     >
@@ -82,7 +82,7 @@
         max-width: calc(38vw - var(--x-size-gap-list-05));
       }
 
-      .x-margin--right-negative {
+      .x-sliding-panel {
         margin-right: calc(-1 * var(--x-size-padding-grid));
       }
     }

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -74,3 +74,10 @@
     protected staggeredFadeAndSlide = StaggeredFadeAndSlide;
   }
 </script>
+
+<style lang="scss">
+  .x-base-grid__next-queries-group {
+    grid-column-start: 1;
+    grid-column-end: -1;
+  }
+</style>

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -25,7 +25,8 @@
               </MainScrollItem>
             </template>
             <template #next-queries-group="{ item: { nextQueries } }">
-              <NextQueriesGroup :nextQueries="nextQueries" />
+              <MobileNextQueryPreview v-if="$x.device === 'mobile'" :nextQuery="nextQueries[0]" />
+              <DesktopNextQueryPreview v-else :nextQuery="nextQueries[0]" />
             </template>
           </BaseVariableColumnGrid>
         </NextQueriesList>
@@ -52,15 +53,17 @@
   import { Component } from 'vue-property-decorator';
   import { NextQueriesList } from '@empathyco/x-components/next-queries';
   import Result from '../../results/result.vue';
-  import NextQueriesGroup from './next-queries-group.vue';
+  import DesktopNextQueryPreview from '../../desktop/desktop-next-query-preview.vue';
+  import MobileNextQueryPreview from '../../mobile/mobile-next-query-preview.vue';
 
   @Component({
     components: {
       Banner,
       BannersList,
       BaseVariableColumnGrid,
+      DesktopNextQueryPreview,
       MainScrollItem,
-      NextQueriesGroup,
+      MobileNextQueryPreview,
       NextQueriesList,
       Promoted,
       PromotedsList,

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -2,11 +2,7 @@
   <ResultsList v-if="$x.totalResults" v-infinite-scroll:main-scroll>
     <BannersList>
       <PromotedsList>
-        <NextQueriesList
-          :offset="24"
-          :frequency="48"
-          :maxNextQueriesPerGroup="$x.device === 'mobile' ? 6 : 12"
-        >
+        <NextQueriesList :offset="24" :frequency="48" :maxNextQueriesPerGroup="1">
           <BaseVariableColumnGrid
             class="x-grid x-padding--top-00"
             :animation="staggeredFadeAndSlide"

--- a/src/design-system/tokens.scss
+++ b/src/design-system/tokens.scss
@@ -25,11 +25,6 @@
   --x-size-gap-tag-default: var(--x-size-base-03);
   --x-number-font-weight-tag-default-selected: var(--x-number-font-weight-base-bold);
 
-  // List
-  .x-list--justify-space-between.x-list {
-    --x-size-justify-list: space-between;
-  }
-
   // Dropdown
   --x-color-border-dropdown-toggle-default: transparent;
   --x-size-padding-left-dropdown-toggle-default: 0;

--- a/src/design-system/tokens.scss
+++ b/src/design-system/tokens.scss
@@ -25,6 +25,11 @@
   --x-size-gap-tag-default: var(--x-size-base-03);
   --x-number-font-weight-tag-default-selected: var(--x-number-font-weight-base-bold);
 
+  // List
+  .x-list--justify-space-between.x-list {
+    --x-size-justify-list: space-between;
+  }
+
   // Dropdown
   --x-color-border-dropdown-toggle-default: transparent;
   --x-size-padding-left-dropdown-toggle-default: 0;

--- a/src/i18n/messages.types.ts
+++ b/src/i18n/messages.types.ts
@@ -37,6 +37,12 @@ export interface Messages {
   nextQueriesGroup: {
     message: string;
   };
+  nextQueryPreview: {
+    title: string;
+    query: string;
+    totalResults: string;
+    viewResults: string;
+  };
   recommendations: {
     title: string;
   };

--- a/src/i18n/messages/en.messages.json
+++ b/src/i18n/messages/en.messages.json
@@ -37,6 +37,12 @@
       "title": "You may be interested",
       "message": "Those who searched for <span class=\"x-text x-text--bold x-font-size--05\">\"{query}\"</span> also viewed:"
     },
+    "nextQueryPreview": {
+      "title": "Next Queries",
+      "query": "{query}",
+      "totalResults": "({totalResults})",
+      "viewResults": "View all results ({totalResults})"
+    },
     "identifierResults": {
       "title": "SKU Search"
     },
@@ -98,6 +104,9 @@
   "mobile": {
     "nextQueriesGroup": {
       "message": "Those who searched for <span class=\"x-text x-text--bold\">\"{query}\"</span> also viewed:"
+    },
+    "nextQueryPreview": {
+      "viewResults": "VIEW ALL"
     },
     "noResults": {
       "message": "<span>Sorry but there are no results for <span class=\"x-text x-font-color--neutral-10 x-text--bold\">\"{query}\"</span></span>You may be interested in these products"

--- a/src/i18n/messages/es.messages.json
+++ b/src/i18n/messages/es.messages.json
@@ -36,6 +36,12 @@
     "nextQueriesGroup": {
       "message": "Los que buscaron <span class=\"x-text x-text--bold x-font-size--05\">\"{query}\"</span> también han visto:"
     },
+    "nextQueryPreview": {
+      "title": "Next Queries",
+      "query": "{query}",
+      "totalResults": "({totalResults})",
+      "viewResults": "Ver todos los resultados ({totalResults})"
+    },
     "recommendations": {
       "title": "Top Clicked"
     },
@@ -94,6 +100,9 @@
   "mobile": {
     "nextQueriesGroup": {
       "message": "Los que buscaron <span class=\"x-text x-text--bold\">\"{query}\"</span> también han visto:"
+    },
+    "nextQueryPreview": {
+      "viewResults": "VER TODOS"
     },
     "noResults": {
       "message": "<span>No se han encontrado resultados para <span class=\"x-text x-font-color--neutral-10 x-text--bold\">\"{query}\"</span></span>Quizás te interesen estos productos"


### PR DESCRIPTION
EX-6658

Changed `components/search/results/results.vue` component used to render the results list in the grid to render a `NextQueryPreview` instead of the `NextQueriesList`.

