### PR TITLE
feat: add styles to partial results

### DIFF
--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -25,9 +25,10 @@
         </LocationProvider>
 
         <LocationProvider location="results">
-          <PartialResults />
+          <PartialResults v-if="$x.device === 'desktop'" />
+          <MobilePartialResults v-else />
         </LocationProvider>
-        <LocationProvider v-if="$x.noResults" location="no_results">
+        <LocationProvider v-if="$x.noResults && !$x.partialResults" location="no_results">
           <Recommendations />
         </LocationProvider>
       </template>
@@ -49,6 +50,7 @@
       CustomQueryPreview,
       PartialResults: () => import('./search').then(m => m.PartialResults),
       Results: () => import('./search').then(m => m.Results),
+      MobilePartialResults: () => import('./search').then(m => m.MobilePartialResults),
       NoResultsMessage: () => import('./search').then(m => m.NoResultsMessage),
       Redirection: () => import('./search').then(m => m.Redirection),
       SpellcheckMessage: () => import('./search').then(m => m.SpellcheckMessage)

--- a/src/components/search/index.ts
+++ b/src/components/search/index.ts
@@ -1,5 +1,6 @@
 import Results from './results/results.vue';
 import PartialResults from './results/partial-results.vue';
+import MobilePartialResults from './results/mobile-partial-results.vue';
 import Sort from './sort.vue';
 import CustomFacets from './facets/custom-facets.vue';
 import SelectedFilters from './facets/selected-filters.vue';
@@ -19,6 +20,7 @@ export {
   NoResultsMessage,
   Results,
   PartialResults,
+  MobilePartialResults,
   Sort,
   DesktopAside,
   MobileAside

--- a/src/components/search/results/mobile-partial-results.vue
+++ b/src/components/search/results/mobile-partial-results.vue
@@ -18,7 +18,7 @@
         </span>
         <PartialQueryButton
           :query="partialResult.query"
-          class="x-title3 x-font-weight--bold x-button--ghost x-margin--left-auto"
+          class="x-text x-font-weight--bold x-button--ghost x-margin--left-auto"
         >
           {{ $t('partialResults.viewResults') }}
           <ChevronRightIcon />
@@ -62,7 +62,7 @@
       SlidingPanel
     }
   })
-  export default class PartialResults extends Vue {}
+  export default class MobilePartialResults extends Vue {}
 </script>
 
 <style lang="scss">
@@ -70,10 +70,6 @@
     .x-partial-results {
       &__result {
         width: calc(38vw - var(--x-size-gap-list-05));
-      }
-
-      .x-sliding-panel__scroll {
-        padding-left: var(--x-size-padding-grid);
       }
     }
   }

--- a/src/components/search/results/mobile-partial-results.vue
+++ b/src/components/search/results/mobile-partial-results.vue
@@ -29,7 +29,14 @@
         :buttonClass="'x-button--ghost x-padding--00'"
         class="x-sliding-panel--show-buttons-on-hover"
       >
-        <ResultsList :results="partialResult.results" />
+        <div class="x-list x-list--gap-05 x-padding--left-05">
+          <Result
+            v-for="result in partialResult.results"
+            :key="result.id"
+            :result="result"
+            class="x-partial-results__result"
+          />
+        </div>
       </SlidingPanel>
     </template>
   </PartialResultsList>

--- a/src/components/search/results/mobile-partial-results.vue
+++ b/src/components/search/results/mobile-partial-results.vue
@@ -1,0 +1,73 @@
+<template>
+  <PartialResultsList class="x-margin--bottom-06 x-list--gap-09">
+    <template #default="{ partialResult }">
+      <div class="x-list x-list--horizontal x-list--align-center x-list--gap-02 x-padding--left-05">
+        <span class="x-title3 x-font-weight--bold">
+          {{
+            $t('partialResults.query', {
+              query: partialResult.query
+            })
+          }}
+        </span>
+        <span class="x-title3 x-font-weight--regular">
+          {{
+            $t('partialResults.totalResults', {
+              totalResults: partialResult.totalResults
+            })
+          }}
+        </span>
+        <PartialQueryButton
+          :query="partialResult.query"
+          class="x-title3 x-font-weight--bold x-button--ghost x-margin--left-auto"
+        >
+          {{ $t('partialResults.viewResults') }}
+          <ChevronRightIcon />
+        </PartialQueryButton>
+      </div>
+      <SlidingPanel
+        :resetOnContentChange="false"
+        :buttonClass="'x-button--ghost x-padding--00'"
+        class="x-sliding-panel--show-buttons-on-hover"
+      >
+        <ResultsList :results="partialResult.results" />
+      </SlidingPanel>
+    </template>
+  </PartialResultsList>
+</template>
+
+<script lang="ts">
+  import { ChevronRightIcon, SlidingPanel } from '@empathyco/x-components';
+  import { Component, Vue } from 'vue-property-decorator';
+  import {
+    PartialQueryButton,
+    PartialResultsList,
+    ResultsList
+  } from '@empathyco/x-components/search';
+  import ResultComponent from '../../results/result.vue';
+
+  @Component({
+    components: {
+      ChevronRightIcon,
+      Result: ResultComponent,
+      PartialResultsList,
+      PartialQueryButton,
+      ResultsList,
+      SlidingPanel
+    }
+  })
+  export default class PartialResults extends Vue {}
+</script>
+
+<style lang="scss">
+  .x-mobile {
+    .x-partial-results {
+      &__result {
+        width: calc(38vw - var(--x-size-gap-list-05));
+      }
+
+      .x-sliding-panel__scroll {
+        padding-left: var(--x-size-padding-grid);
+      }
+    }
+  }
+</style>

--- a/src/components/search/results/partial-results.vue
+++ b/src/components/search/results/partial-results.vue
@@ -24,7 +24,7 @@
           <ChevronRightIcon />
         </PartialQueryButton>
       </div>
-      <BaseGrid columns="4" :items="partialResult.results.slice(0, maxItemsToRender)">
+      <BaseGrid columns="4" :items="partialResult.results">
         <template #result="{ item }">
           <Result :result="item" />
         </template>
@@ -35,7 +35,7 @@
 
 <script lang="ts">
   import { BaseGrid, ChevronRightIcon } from '@empathyco/x-components';
-  import { Component, Prop, Vue } from 'vue-property-decorator';
+  import { Component, Vue } from 'vue-property-decorator';
   import { PartialQueryButton, PartialResultsList } from '@empathyco/x-components/search';
   import ResultComponent from '../../results/result.vue';
 
@@ -48,8 +48,5 @@
       PartialQueryButton
     }
   })
-  export default class PartialResults extends Vue {
-    @Prop({ default: 4 })
-    protected maxItemsToRender!: number;
-  }
+  export default class PartialResults extends Vue {}
 </script>

--- a/src/components/search/results/partial-results.vue
+++ b/src/components/search/results/partial-results.vue
@@ -1,32 +1,55 @@
 <template>
-  <PartialResultsList>
+  <PartialResultsList class="x-margin--bottom-06 x-list--gap-12">
     <template #default="{ partialResult }">
-      <span>{{ partialResult.query }}</span>
-      <BaseGrid :columns="$x.device === 'mobile' ? 2 : 4" :items="partialResult.results">
+      <div class="x-list x-list--horizontal x-list--align-center x-list--gap-02">
+        <span class="x-title3 x-font-weight--bold">
+          {{
+            $t('partialResults.query', {
+              query: partialResult.query
+            })
+          }}
+        </span>
+        <span class="x-title3 x-font-weight--regular">
+          {{
+            $t('partialResults.totalResults', {
+              totalResults: partialResult.totalResults
+            })
+          }}
+        </span>
+        <PartialQueryButton
+          :query="partialResult.query"
+          class="x-title3 x-font-weight--bold x-button--ghost x-margin--left-auto"
+        >
+          {{ $t('partialResults.viewResults') }}
+          <ChevronRightIcon />
+        </PartialQueryButton>
+      </div>
+      <BaseGrid columns="4" :items="partialResult.results.slice(0, maxItemsToRender)">
         <template #result="{ item }">
           <Result :result="item" />
         </template>
       </BaseGrid>
-      <PartialQueryButton :query="partialResult.query">
-        {{ $t('partialResults.message', partialResult.results.length) }}
-      </PartialQueryButton>
     </template>
   </PartialResultsList>
 </template>
 
 <script lang="ts">
-  import { BaseGrid } from '@empathyco/x-components';
-  import { Component, Vue } from 'vue-property-decorator';
+  import { BaseGrid, ChevronRightIcon } from '@empathyco/x-components';
+  import { Component, Prop, Vue } from 'vue-property-decorator';
   import { PartialQueryButton, PartialResultsList } from '@empathyco/x-components/search';
   import ResultComponent from '../../results/result.vue';
 
   @Component({
     components: {
       BaseGrid,
+      ChevronRightIcon,
       Result: ResultComponent,
       PartialResultsList,
       PartialQueryButton
     }
   })
-  export default class PartialResults extends Vue {}
+  export default class PartialResults extends Vue {
+    @Prop({ default: 4 })
+    protected maxItemsToRender!: number;
+  }
 </script>

--- a/src/design-system/tokens.scss
+++ b/src/design-system/tokens.scss
@@ -36,6 +36,9 @@
     --x-size-padding-grid: 0;
   }
 
+  // Image
+  --x-number-aspect-ratio-picture: 3/4;
+
   // Result
   --x-size-gap-result-default: var(--x-size-base-02);
 

--- a/src/design-system/tokens.scss
+++ b/src/design-system/tokens.scss
@@ -32,16 +32,14 @@
   --x-size-min-width-grid-item: var(--x-size-base-20);
   --x-size-gap-grid: var(--x-size-base-07) var(--x-size-base-05);
   --x-size-padding-grid: var(--x-size-base-06) 0;
+  .x-partial-result {
+    --x-size-padding-grid: 0;
+  }
 
   // Result
   --x-size-gap-result-default: var(--x-size-base-02);
 
   // Message
-  --x-color-background-message-default: var(--x-color-base-neutral-95);
-  --x-color-border-message-default: var(--x-color-background-message-default);
-  --x-color-text-message-default: var(--x-color-text-default);
-  --x-size-border-width-message-default: var(--x-size-border-width-base);
-  --x-space-padding-message: var(--x-size-base-06);
   --x-size-border-radius-message-default: 0;
 
   .x-message {

--- a/src/i18n/messages.types.ts
+++ b/src/i18n/messages.types.ts
@@ -61,7 +61,9 @@ export interface Messages {
     showLess: string;
   };
   partialResults: {
-    message: string;
+    query: string;
+    totalResults: string;
+    viewResults: string;
   };
   priceFilter: {
     lessThan: string;

--- a/src/i18n/messages/en.messages.json
+++ b/src/i18n/messages/en.messages.json
@@ -63,7 +63,9 @@
       "showLess": "Show less"
     },
     "partialResults": {
-      "message": "View all results ({totalResults})"
+      "query": "{query}",
+      "totalResults": "({totalResults})",
+      "viewResults": "View all"
     },
     "priceFilter": {
       "lessThan": "less than {max}",

--- a/src/i18n/messages/es.messages.json
+++ b/src/i18n/messages/es.messages.json
@@ -60,7 +60,9 @@
       "showLess": "Mostrar menos"
     },
     "partialResults": {
-      "message": "Ver todos los resultados ({totalResults})"
+      "query": "{query}",
+      "totalResults": "({totalResults})",
+      "viewResults": "Ver todos los resultados"
     },
     "priceFilter": {
       "lessThan": "hasta {max}",

--- a/src/i18n/messages/fr.messages.json
+++ b/src/i18n/messages/fr.messages.json
@@ -63,7 +63,9 @@
       "showLess": "Montrer moins"
     },
     "partialResults": {
-      "message": "Afficher tous les résultats ({totalResults})"
+      "query": "{query}",
+      "totalResults": "({totalResults})",
+      "viewResults": "Afficher tous les résultats"
     },
     "priceFilter": {
       "lessThan": "moins de {max}",


### PR DESCRIPTION
I know that some colors are not matching, cris is working on that. Right now the colors that we set in tailwind are not the same that the ones that the design has, so for example, the x-text is using neutral-10, instead of overwriting the token in the archetype what we have to do is set that value in tailwind.

What we want to achieve is that we should not override things in the archetype, everything has to be set as default in tailwind.

EX-4515