### PR TITLE
feat: enable `devtools` in Empathy environments

### DIFF
--- a/build/instrumentation.build.js
+++ b/build/instrumentation.build.js
@@ -104,7 +104,10 @@ export function createConfig({
             'inject',
             (varname, id) =>
               // eslint-disable-next-line max-len
-              `import {createInjector} from 'vue-runtime-helpers';const injector=createInjector({});injector('${id}',{source:${varname}})`
+              `import {createInjector} from 'vue-runtime-helpers';const injector=createInjector({});injector('${id.replace(
+                /\\/g,
+                ''
+              )}',{source:${varname}})`
           ]
         })
       ),

--- a/build/instrumentation.build.js
+++ b/build/instrumentation.build.js
@@ -103,6 +103,8 @@ export function createConfig({
           mode: [
             'inject',
             (varname, id) =>
+              // For this to work on windows systems, the `id` which is a file path has to replace the backslashes with
+              // another symbol like forward slashes.
               // eslint-disable-next-line max-len
               `import {createInjector} from 'vue-runtime-helpers';const injector=createInjector({});injector('${id.replace(
                 /\\/g,

--- a/public/snippet-script.js
+++ b/public/snippet-script.js
@@ -38,6 +38,7 @@ var currency = getURLParameter('currency') || 'EUR';
 var consent = getURLParameter('consent') !== 'false';
 var documentDirection = getURLParameter('doc-dir') || 'ltr';
 
+window.__enableVueDevtools__ = true;
 window.initX = {
   instance,
   env,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,13 @@ import { XInstaller } from '@empathyco/x-components';
 import Vue from 'vue';
 import { installXOptions } from './x-components/plugin.options';
 
+declare global {
+  interface Window {
+    __enableVueDevtools__?: boolean;
+  }
+}
+
 Vue.config.productionTip = false;
+Vue.config.devtools = window.__enableVueDevtools__ ?? false;
 
 new XInstaller(installXOptions).init();


### PR DESCRIPTION
- Enables devtools as long as the `__enableVueDevtools__` variable is `true`. 
- Sets the `__enableVueDevtools__` in Empathy environments.
- Fixes compilation in Windows devices.