### PR TITLE
fix: fix styles for the selected filters reverting previous changes

### DIFF
--- a/src/components/search/facets/selected-filters.vue
+++ b/src/components/search/facets/selected-filters.vue
@@ -23,8 +23,8 @@
             :filter="filter"
           >
             <template #label="{ filter }">
-              <span>{{ filter.label }}</span>
-              <CrossTinyIcon />
+              <span class="x-text x-text--bold x-font-color--accent">{{ filter.label }}</span>
+              <CrossTinyIcon class="x-font-color--accent" />
             </template>
           </SimpleFilter>
         </template>
@@ -32,16 +32,15 @@
         <template #price="{ filter }">
           <NumberRangeFilter
             class="
-              x-button x-button-auxiliary x-button-sm
-              x-border-radius--20
-              x-padding--05 x-padding--top-03 x-padding--bottom-03
-              x-border-width--00
+              x-tag x-tag--pill x-tag--ghost
+              x-background--auxiliary
+              x-padding--04 x-padding--top-03 x-padding--bottom-03
             "
             :filter="filter"
           >
             <template #label="{ filter }">
-              <PriceFilterLabel :filter="filter" />
-              <CrossTinyIcon />
+              <PriceFilterLabel class="x-text x-text--bold x-font-color--accent" :filter="filter" />
+              <CrossTinyIcon class="x-font-color--accent" />
             </template>
           </NumberRangeFilter>
         </template>
@@ -55,13 +54,7 @@
       v-if="$x.device === 'desktop'"
       v-slot="{ selectedFilters }"
       data-test="clear-filters-toolbar"
-      class="
-        x-button-sm x-button-lead x-button-outlined
-        x-border-radius--20
-        x-padding--05 x-padding--top-03 x-padding--bottom-03
-        x-margin--left-03
-        x-list__item--flex-none
-      "
+      class="x-button-sm x-button-lead x-button-outlined x-border-radius--20 x-margin--left-03"
       :alwaysVisible="false"
     >
       {{ $t('selectedFilters.clear', { selectedFiltersNumber: selectedFilters.length }) }}

--- a/src/components/search/facets/selected-filters.vue
+++ b/src/components/search/facets/selected-filters.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="x-list x-list--horizontal x-list--align-center">
+  <div class="x-list x-list--horizontal x-list--align-center x-list--gap-03">
     <SlidingPanel
-      class="x-sliding-panel--show-buttons-on-hover"
+      class="x-sliding-panel--show-buttons-on-hover x-list--gap-09"
       :showButtons="$x.device === 'mobile' ? false : true"
       buttonClass="x-button-lead x-button-circle x-button-ghost x-padding--00"
       :resetOnContentChange="false"
@@ -54,7 +54,7 @@
       v-if="$x.device === 'desktop'"
       v-slot="{ selectedFilters }"
       data-test="clear-filters-toolbar"
-      class="x-button-sm x-button-lead x-button-outlined x-border-radius--20 x-margin--left-03"
+      class="x-button-sm x-button-lead x-button-outlined x-border-radius--20"
       :alwaysVisible="false"
     >
       {{ $t('selectedFilters.clear', { selectedFiltersNumber: selectedFilters.length }) }}

--- a/src/components/search/facets/selected-filters.vue
+++ b/src/components/search/facets/selected-filters.vue
@@ -54,7 +54,11 @@
       v-if="$x.device === 'desktop'"
       v-slot="{ selectedFilters }"
       data-test="clear-filters-toolbar"
-      class="x-button-sm x-button-lead x-button-outlined x-border-radius--20"
+      class="
+        x-button-sm x-button-lead x-button-outlined
+        x-border-radius--20
+        x-list__item--flex-none
+      "
       :alwaysVisible="false"
     >
       {{ $t('selectedFilters.clear', { selectedFiltersNumber: selectedFilters.length }) }}

--- a/src/components/search/facets/selected-filters.vue
+++ b/src/components/search/facets/selected-filters.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="x-list x-list--horizontal x-list--align-center x-list--gap-03">
     <SlidingPanel
-      class="x-sliding-panel--show-buttons-on-hover x-list--gap-09"
+      class="x-sliding-panel--show-buttons-on-hover"
       :showButtons="$x.device === 'mobile' ? false : true"
       buttonClass="x-button-lead x-button-circle x-button-ghost x-padding--00"
       :resetOnContentChange="false"


### PR DESCRIPTION
EX-7431


## Motivation and context
Selected filters are tags, so they should be changed to buttons (they'll be their own component). The changes in the previous PR should be reverted.
Also, removing the custom paddings for the clear filters, the mismatch between tags and buttons sizes should be fixed with the tag component.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify: