### PR TITLE
feat: Display Spellckeck above results toolbar

### DIFF
--- a/src/components/desktop/desktop.vue
+++ b/src/components/desktop/desktop.vue
@@ -38,10 +38,10 @@
     </template>
 
     <template #sub-header v-if="!$x.redirections.length">
-      <LocationProvider location="no_results">
+      <LocationProvider location="results">
         <SpellcheckMessage class="x-margin--bottom-05" data-test="spellcheck-message" />
-        <NoResultsMessage class="x-margin--bottom-05" data-test="no-results-message" />
       </LocationProvider>
+      <NoResultsMessage class="x-margin--bottom-05" data-test="no-results-message" />
       <DesktopToolbar />
     </template>
 

--- a/src/components/desktop/desktop.vue
+++ b/src/components/desktop/desktop.vue
@@ -38,8 +38,10 @@
     </template>
 
     <template #sub-header v-if="!$x.redirections.length">
-      <SpellcheckMessage class="x-margin--bottom-05" data-test="spellcheck-message" />
-      <NoResultsMessage class="x-margin--bottom-05" data-test="no-results-message" />
+      <LocationProvider location="no_results">
+        <SpellcheckMessage class="x-margin--bottom-05" data-test="spellcheck-message" />
+        <NoResultsMessage class="x-margin--bottom-05" data-test="no-results-message" />
+      </LocationProvider>
       <DesktopToolbar />
     </template>
 

--- a/src/components/desktop/desktop.vue
+++ b/src/components/desktop/desktop.vue
@@ -37,7 +37,9 @@
       </div>
     </template>
 
-    <template #sub-header>
+    <template #sub-header v-if="!$x.redirections.length">
+      <SpellcheckMessage class="x-margin--bottom-05" data-test="spellcheck-message" />
+      <NoResultsMessage class="x-margin--bottom-05" data-test="no-results-message" />
       <DesktopToolbar />
     </template>
 
@@ -125,7 +127,9 @@
       SlidingPanel,
       RelatedTags: () => import('../search').then(m => m.RelatedTags),
       SelectedFilters: () => import('../search').then(m => m.SelectedFilters),
-      DesktopAside: () => import('../search').then(m => m.DesktopAside)
+      DesktopAside: () => import('../search').then(m => m.DesktopAside),
+      NoResultsMessage: () => import('../search').then(m => m.NoResultsMessage),
+      SpellcheckMessage: () => import('../search').then(m => m.SpellcheckMessage)
     }
   })
   export default class Desktop extends HasSearchedMixin {

--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -9,17 +9,6 @@
       <Redirection />
 
       <template v-if="!$x.redirections.length">
-        <div
-          v-if="$x.totalResults === 0 || $x.spellcheckedQuery"
-          class="x-padding--top-03 x-padding--bottom-07"
-          :class="{ 'x-margin--left-05 x-margin--right-05': $x.device === 'mobile' }"
-        >
-          <template>
-            <SpellcheckMessage data-test="spellcheck-message" />
-            <NoResultsMessage data-test="no-results-message" />
-          </template>
-        </div>
-
         <LocationProvider location="results">
           <Results />
         </LocationProvider>
@@ -51,9 +40,7 @@
       PartialResults: () => import('./search').then(m => m.PartialResults),
       Results: () => import('./search').then(m => m.Results),
       MobilePartialResults: () => import('./search').then(m => m.MobilePartialResults),
-      NoResultsMessage: () => import('./search').then(m => m.NoResultsMessage),
-      Redirection: () => import('./search').then(m => m.Redirection),
-      SpellcheckMessage: () => import('./search').then(m => m.SpellcheckMessage)
+      Redirection: () => import('./search').then(m => m.Redirection)
     }
   })
   export default class Main extends HasSearchedMixin {}

--- a/src/components/mobile/mobile.vue
+++ b/src/components/mobile/mobile.vue
@@ -34,7 +34,7 @@
     </template>
 
     <template #toolbar v-if="$x.query.search && !$x.redirections.length">
-      <div>
+      <div class="x-flex-1">
         <SpellcheckMessage
           class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
           data-test="spellcheck-message"

--- a/src/components/mobile/mobile.vue
+++ b/src/components/mobile/mobile.vue
@@ -35,14 +35,16 @@
 
     <template #toolbar v-if="$x.query.search && !$x.redirections.length">
       <div class="x-flex-1">
-        <SpellcheckMessage
-          class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
-          data-test="spellcheck-message"
-        />
-        <NoResultsMessage
-          class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
-          data-test="no-results-message"
-        />
+        <LocationProvider location="no_results">
+          <SpellcheckMessage
+            class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
+            data-test="spellcheck-message"
+          />
+          <NoResultsMessage
+            class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
+            data-test="no-results-message"
+          />
+        </LocationProvider>
         <MobileToolbar class="x-padding--left-05 x-padding--bottom-05 x-padding--right-03" />
       </div>
     </template>

--- a/src/components/mobile/mobile.vue
+++ b/src/components/mobile/mobile.vue
@@ -33,8 +33,18 @@
       </div>
     </template>
 
-    <template #toolbar v-if="$x.query.search">
-      <MobileToolbar class="x-padding--left-05 x-padding--bottom-05 x-padding--right-03" />
+    <template #toolbar v-if="$x.query.search && !$x.redirections.length">
+      <div>
+        <SpellcheckMessage
+          class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
+          data-test="spellcheck-message"
+        />
+        <NoResultsMessage
+          class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
+          data-test="no-results-message"
+        />
+        <MobileToolbar class="x-padding--left-05 x-padding--bottom-05 x-padding--right-03" />
+      </div>
     </template>
 
     <template #predictive>
@@ -125,7 +135,9 @@
       SearchBox,
       SingleColumnLayout,
       MobileAside: () => import('../search').then(m => m.MobileAside),
-      RelatedTags: () => import('../search').then(m => m.RelatedTags)
+      NoResultsMessage: () => import('../search').then(m => m.NoResultsMessage),
+      RelatedTags: () => import('../search').then(m => m.RelatedTags),
+      SpellcheckMessage: () => import('../search').then(m => m.SpellcheckMessage)
     }
   })
   export default class Mobile extends HasSearchedMixin {

--- a/src/components/mobile/mobile.vue
+++ b/src/components/mobile/mobile.vue
@@ -35,16 +35,16 @@
 
     <template #toolbar v-if="$x.query.search && !$x.redirections.length">
       <div class="x-flex-1">
-        <LocationProvider location="no_results">
+        <LocationProvider location="results">
           <SpellcheckMessage
             class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
             data-test="spellcheck-message"
           />
-          <NoResultsMessage
-            class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
-            data-test="no-results-message"
-          />
         </LocationProvider>
+        <NoResultsMessage
+          class="x-margin--bottom-05 x-margin--left-05 x-margin--right-03"
+          data-test="no-results-message"
+        />
         <MobileToolbar class="x-padding--left-05 x-padding--bottom-05 x-padding--right-03" />
       </div>
     </template>


### PR DESCRIPTION
[EX-7243](https://searchbroker.atlassian.net/browse/EX-7243)

With this change we are losing the origin when clicking on the spellcheck button:
- Before:
![Screenshot 2022-11-18 at 09 06 09](https://user-images.githubusercontent.com/72568818/202652148-a6f4941e-2a6a-48f9-9405-1dbdb0cae471.png)
- After:
![Screenshot 2022-11-18 at 09 06 21](https://user-images.githubusercontent.com/72568818/202652178-18522da6-5370-4af9-9c6e-e06cdd6f7c10.png)

I think that origin doesn't represent anything relevant in the case of a spellcheck, but happy to read different opinions :)