### PR TITLE
build: enable `whitespace: 'condense'` in `rollup-plugin-vue`

### DIFF
--- a/build/instrumentation.build.js
+++ b/build/instrumentation.build.js
@@ -87,7 +87,12 @@ export function createConfig({
       vue(
         mergeConfig('vue', {
           css: false,
-          needMap: false
+          needMap: false,
+          template: {
+            compilerOptions: {
+              whitespace: 'condense'
+            }
+          }
         })
       ),
       typescript(


### PR DESCRIPTION
EX-7706

Sets rollup-plugin-vue `whitespace` option to `'condense'` to match the [Vue CLI defaults](https://cli.vuejs.org/migrations/migrate-from-v3.html#vue-cli-service). This should prevent empty text nodes from being generated in the output, and prevent us from having different behaviors between dev and production builds.

![image](https://user-images.githubusercontent.com/68222542/209822357-1d93f931-2fd3-46d6-b3ab-35f4cedddf7d.png)


