### PR TITLE
fix: no-results are now correctly displayed

### DIFF
--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -17,7 +17,7 @@
           <PartialResults v-if="$x.device === 'desktop'" />
           <MobilePartialResults v-else />
         </LocationProvider>
-        <LocationProvider v-if="$x.noResults && !$x.partialResults" location="no_results">
+        <LocationProvider v-if="$x.noResults && !$x.partialResults.length" location="no_results">
           <Recommendations />
         </LocationProvider>
       </template>

--- a/tests/e2e/cucumber/no-results.feature
+++ b/tests/e2e/cucumber/no-results.feature
@@ -5,6 +5,7 @@ Feature: No-results component
     When  start button is clicked
     And   "<query>" is searched
     Then  no results message is displayed
+    And   recommendations are displayed
     And   there are no results
     Examples:
       | query    | view        |


### PR DESCRIPTION
EX-7717

The rendering condition was wrong. Now the no-results reccommendations are correctly displayed:

Before:
![image](https://user-images.githubusercontent.com/68222542/210050266-1a231634-f52f-4d18-bbfc-5ac8ac438974.png)

After:
![image](https://user-images.githubusercontent.com/68222542/210050293-5d266d34-cf8c-497b-8200-af3d27fccbd4.png)
