### PR TITLE
feat: add results count to my history

### DIFF
--- a/src/components/my-history/custom-my-history.vue
+++ b/src/components/my-history/custom-my-history.vue
@@ -83,6 +83,14 @@
                     <span>{{ suggestion.query }}</span>
                     <span class="x-text1 x-text1-sm x-text-neutral-75">
                       {{ formatTime(suggestion.timestamp) }}
+                      <template v-if="suggestion.totalResults !== undefined">
+                        -
+                        {{
+                          $t('myHistory.suggestionResults', {
+                            totalResults: suggestion.totalResults
+                          })
+                        }}
+                      </template>
                     </span>
                   </div>
                 </div>

--- a/src/i18n/messages.types.ts
+++ b/src/i18n/messages.types.ts
@@ -19,6 +19,7 @@ export interface Messages {
     message: string;
     noHistory: string;
     openButton: string;
+    suggestionResults: string;
     switch: {
       title: string;
       enable: string;

--- a/src/i18n/messages/en.messages.json
+++ b/src/i18n/messages/en.messages.json
@@ -18,6 +18,7 @@
       "message": "<span>This data are stored locally. Just in your device and never travel outside of it.</span><span>You can disable the history queries whenever you want.</span><span class=\"x-title3\">Your privacy under your control.</span>",
       "noHistory": "No history activity to show",
       "openButton": "My History",
+      "suggestionResults": "({totalResults} results)",
       "switch": {
         "title": "History Queries",
         "enable": "Enable",

--- a/src/i18n/messages/es.messages.json
+++ b/src/i18n/messages/es.messages.json
@@ -18,6 +18,7 @@
       "message": "<span>Los datos se guardan en local. Solo están en tu dispositivo y nunca salen de ahí.</span><span>Puedes desactivar el historial de búsqueda cuando quieras.</span><span class=\"x-title3\">Tu privacidad bajo tu control.</span>",
       "noHistory": "No hay historial de búsqueda para mostrar",
       "openButton": "Mi Historial",
+      "suggestionResults": "({totalResults} resultados)",
       "switch": {
         "title": "Historial de búsqueda",
         "enable": "Activar",

--- a/src/i18n/messages/fr.messages.json
+++ b/src/i18n/messages/fr.messages.json
@@ -18,6 +18,7 @@
       "message": "<span>Ces données sont stockées localement. Juste dans votre appareil et ne voyagez jamais en dehors de celui-ci.</span><span>Vous pouvez désactiver les requêtes d'historique quand vous le souhaitez.</span><span class=\"x-title3\">Votre vie privée sous votre contrôle.</span>",
       "noHistory": "Aucune activité d'historique à afficher",
       "openButton": "Mon histoire",
+      "suggestionResults": "({totalResults} résultats)",
       "switch": {
         "title": "Requêtes d'historique",
         "enable": "Activer",

--- a/src/i18n/messages/pt.messages.json
+++ b/src/i18n/messages/pt.messages.json
@@ -18,6 +18,7 @@
       "message": "<span>Seus dados são salvos localmente. Ficam apenas em seu dispositivo e não são compartilhados externamente.</span><span> Você pode desativar o seu histórico de buscas sempre que desejar.</span><span class=\"x-title3\">Sua privacidade sob seu controle.</span>",
       "noHistory": "Não há histórico de buscas para mostrar",
       "openButton": "Meu histórico",
+      "suggestionResults": "({totalResults} resultados)",
       "switch": {
         "title": "Histórico de buscas",
         "enable": "Ativo",


### PR DESCRIPTION
EX-7449

Adds the results count to the MyHistory component:

Result:
![image](https://user-images.githubusercontent.com/68222542/210812123-a38e3bc1-4dbc-4c33-8e03-6e9baaa9df72.png)

[Design](https://www.figma.com/file/mYfJZHn668mGEGf61Sji6m/X-Archetype?node-id=3744%3A49475&t=PmLir2dlP89XfLcQ-0):
![image](https://user-images.githubusercontent.com/68222542/210812271-943428d2-8ec7-4adc-afcb-bc247e8619c0.png)


