### PR TITLE
feat!(i18n): replace `v-html` with `i18n` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "devDependencies": {
         "@cypress/webpack-preprocessor": "~5.11.1",
         "@empathyco/eslint-plugin-x": "^2.0.0-alpha.21",
-        "@empathyco/x-tailwindcss": "^0.2.0-alpha.41",
+        "@empathyco/x-tailwindcss": "^0.2.0-alpha.44",
         "@empathyco/x-translations": "^1.1.0-alpha.30",
         "@rollup/plugin-commonjs": "~21.0.1",
         "@rollup/plugin-json": "~4.1.0",
@@ -2161,14 +2161,14 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@empathyco/x-tailwindcss": {
-      "version": "0.2.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-tailwindcss/-/x-tailwindcss-0.2.0-alpha.41.tgz",
-      "integrity": "sha512-dTXY4CQwFS34psLJrJsVooxOMsXy0LvN9raOCDtYniucB02v04L4lJiU1Zv5/3Hpo3D1f4j/9aCiasl8WtU3Vg==",
+      "version": "0.2.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-tailwindcss/-/x-tailwindcss-0.2.0-alpha.44.tgz",
+      "integrity": "sha512-36Fvk2D+KoMVHoyF1FxKK63zDFQEqyl4vLEjVeGhmiFKxr8Fz9R3SH2LRJ+5GF3wsNd4m5+nE2iW2iPt0zFadQ==",
       "dev": true,
       "dependencies": {
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.26",
-        "@empathyco/x-utils": "^1.0.0-alpha.12",
-        "tslib": "~2.3.0"
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.27",
+        "@empathyco/x-utils": "^1.0.0-alpha.13",
+        "tslib": "~2.4.1"
       },
       "engines": {
         "node": "16"
@@ -2189,6 +2189,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@empathyco/x-tailwindcss/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
     },
     "node_modules/@empathyco/x-translations": {
       "version": "1.1.0-alpha.30",
@@ -28987,14 +28993,22 @@
       }
     },
     "@empathyco/x-tailwindcss": {
-      "version": "0.2.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-tailwindcss/-/x-tailwindcss-0.2.0-alpha.41.tgz",
-      "integrity": "sha512-dTXY4CQwFS34psLJrJsVooxOMsXy0LvN9raOCDtYniucB02v04L4lJiU1Zv5/3Hpo3D1f4j/9aCiasl8WtU3Vg==",
+      "version": "0.2.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-tailwindcss/-/x-tailwindcss-0.2.0-alpha.44.tgz",
+      "integrity": "sha512-36Fvk2D+KoMVHoyF1FxKK63zDFQEqyl4vLEjVeGhmiFKxr8Fz9R3SH2LRJ+5GF3wsNd4m5+nE2iW2iPt0zFadQ==",
       "dev": true,
       "requires": {
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.26",
-        "@empathyco/x-utils": "^1.0.0-alpha.12",
-        "tslib": "~2.3.0"
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.27",
+        "@empathyco/x-utils": "^1.0.0-alpha.13",
+        "tslib": "~2.4.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
       }
     },
     "@empathyco/x-translations": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "~5.11.1",
     "@empathyco/eslint-plugin-x": "^2.0.0-alpha.21",
-    "@empathyco/x-tailwindcss": "^0.2.0-alpha.41",
+    "@empathyco/x-tailwindcss": "^0.2.0-alpha.44",
     "@empathyco/x-translations": "^1.1.0-alpha.30",
     "@rollup/plugin-commonjs": "~21.0.1",
     "@rollup/plugin-json": "~4.1.0",

--- a/src/components/desktop/desktop-toolbar.vue
+++ b/src/components/desktop/desktop-toolbar.vue
@@ -4,10 +4,16 @@
     class="x-list x-list--horizontal x-list--gap-06 x-list--justify-end x-list--align-center"
     data-test="total-results"
   >
-    <span
-      v-html="$t('totalResults.message', { totalResults: $x.totalResults, query })"
-      class="x-text1 x-text1-lg x-list__item--expand"
-    />
+    <i18n class="x-text1 x-text1-lg x-list__item--expand" path="totalResults.message" tag="span">
+      <template #totalResults>
+        {{ $x.totalResults }}
+      </template>
+      <template #query>
+        <span class="x-title3">
+          {{ query }}
+        </span>
+      </template>
+    </i18n>
 
     <ColumnPicker data-test="column-picker" />
 

--- a/src/components/my-history/custom-my-history.vue
+++ b/src/components/my-history/custom-my-history.vue
@@ -28,10 +28,18 @@
         <h2 class="x-title3">
           {{ $t('myHistory.subtitle') }}
         </h2>
-        <div
-          v-html="$t('myHistory.message')"
-          class="x-list x-list--gap-05 x-text1 x-text1-lg x-text-neutral-75"
-        ></div>
+
+        <div class="x-list x-list--gap-05 x-text1 x-text1-lg x-text-neutral-75">
+          <span>
+            {{ $t('myHistory.message.header') }}
+          </span>
+          <span>
+            {{ $t('myHistory.message.body') }}
+          </span>
+          <span class="x-title3">
+            {{ $t('myHistory.message.footer') }}
+          </span>
+        </div>
       </div>
       <div
         class="

--- a/src/components/search/no-results-message.vue
+++ b/src/components/search/no-results-message.vue
@@ -1,9 +1,15 @@
 <template>
-  <span
+  <i18n
     v-if="$x.noResults"
-    v-html="$t('noResults.message', { query: $x.query.search })"
     class="x-text1 x-no-results-message x-message x-break-words desktop:x-text1-lg"
-  />
+    path="noResults.message"
+  >
+    <template #query>
+      <span class="x-font-bold">
+        {{ $x.query.search }}
+      </span>
+    </template>
+  </i18n>
 </template>
 
 <script lang="ts">

--- a/src/components/search/results/next-queries-group.vue
+++ b/src/components/search/results/next-queries-group.vue
@@ -8,10 +8,13 @@
         : 'x-padding--06 x-padding--bottom-07'
     "
   >
-    <p
-      v-html="$t('nextQueriesGroup.message', { query: $x.query.search })"
-      class="x-text1 desktop:x-text1-lg"
-    />
+    <i18n class="x-text1 desktop:x-text1-lg" path="nextQueriesGroup.message" tag="p">
+      <template #query>
+        <span class="x-title3">
+          {{ $x.query.search }}
+        </span>
+      </template>
+    </i18n>
     <BaseSuggestions
       #default="{ suggestion }"
       :suggestions="nextQueries"

--- a/src/components/search/spellcheck-message.vue
+++ b/src/components/search/spellcheck-message.vue
@@ -1,11 +1,14 @@
 <template>
   <Spellcheck v-if="$x.totalResults > 0" #default="{ query }" class="x-message">
     <p>
-      <span
-        v-html="$t('spellcheck.message', { query })"
-        class="x-text1 x-break-words desktop:x-text1-lg"
-      />
-      <SpellcheckButton class="x-button x-button-lead x-button-tight" />
+      <i18n class="x-text1 x-break-words desktop:x-text1-lg" path="spellcheck.message" tag="span">
+        <template #query>
+          <span class="x-text x-font-bold x-text-auxiliary-50">
+            {{ query }}
+          </span>
+        </template>
+      </i18n>
+      <SpellcheckButton class="x-button x-button-link x-button-lead x-padding--left-01" />
     </p>
   </Spellcheck>
 </template>

--- a/src/i18n/messages.types.ts
+++ b/src/i18n/messages.types.ts
@@ -16,7 +16,11 @@ export interface Messages {
   myHistory: {
     title: string;
     subtitle: string;
-    message: string;
+    message: {
+      header: string;
+      body: string;
+      footer: string;
+    };
     noHistory: string;
     openButton: string;
     suggestionResults: string;

--- a/src/i18n/messages/en.messages.json
+++ b/src/i18n/messages/en.messages.json
@@ -98,7 +98,7 @@
       "addToCart": "ADD TO CART"
     },
     "spellcheck": {
-      "message": "No results found for <span class=\"x-font-bold x-text-auxiliary-50 \">'{query}'</span>. We show you results for"
+      "message": "No results found for '{query}'. We show you results for"
     },
     "noResults": {
       "message": "Sorry but there are no results for {query}You may be interested in these products"

--- a/src/i18n/messages/en.messages.json
+++ b/src/i18n/messages/en.messages.json
@@ -15,7 +15,11 @@
     "myHistory": {
       "title": "My History",
       "subtitle": "This is the complete list of history queries",
-      "message": "<span>This data are stored locally. Just in your device and never travel outside of it.</span><span>You can disable the history queries whenever you want.</span><span class=\"x-title3\">Your privacy under your control.</span>",
+      "message": {
+        "header": "This data is stored locally. Just in your device and never travel outside of it.",
+        "body": "You can disable the history queries whenever you want.",
+        "footer": "Your privacy under your control."
+      },
       "noHistory": "No history activity to show",
       "openButton": "My History",
       "suggestionResults": "({totalResults} results)",
@@ -35,7 +39,7 @@
       "title": "What's Next"
     },
     "nextQueriesGroup": {
-      "message": "Those who searched for <span class=\"x-title3\">\"{query}\"</span> also viewed:"
+      "message": "Those who searched for {query} also viewed:"
     },
     "nextQueryPreview": {
       "message": "Those who searched for {query} also viewed:",
@@ -77,7 +81,7 @@
       "showAside": "Sort & Filter"
     },
     "totalResults": {
-      "message": "{totalResults} results for <span class=\"x-title3\">{query}</span>"
+      "message": "{totalResults} results for {query}"
     },
     "sort": {
       "label": "Sort by",
@@ -97,7 +101,7 @@
       "message": "No results found for <span class=\"x-font-bold x-text-auxiliary-50 \">'{query}'</span>. We show you results for"
     },
     "noResults": {
-      "message": "<span>Sorry but there are no results for <span class=\"x-font-bold \">\"{query}\"</span></span>You may be interested in these products"
+      "message": "Sorry but there are no results for {query}You may be interested in these products"
     },
     "columnPicker": {
       "message": "View"
@@ -108,7 +112,7 @@
   },
   "mobile": {
     "nextQueriesGroup": {
-      "message": "Those who searched for <span class=\"x-title3\">\"{query}\"</span> also viewed:"
+      "message": "Those who searched for {query} also viewed:"
     },
     "nextQueryPreview": {
       "viewResults": "View all"

--- a/src/i18n/messages/es.messages.json
+++ b/src/i18n/messages/es.messages.json
@@ -15,7 +15,11 @@
     "myHistory": {
       "title": "Mi Historial",
       "subtitle": "Este es tu historial de búsqueda",
-      "message": "<span>Los datos se guardan en local. Solo están en tu dispositivo y nunca salen de ahí.</span><span>Puedes desactivar el historial de búsqueda cuando quieras.</span><span class=\"x-title3\">Tu privacidad bajo tu control.</span>",
+      "message": {
+        "header": "Los datos se guardan en local. Solo están en tu dispositivo y nunca salen de ahí.",
+        "body": "Puedes desactivar el historial de búsqueda cuando quieras.",
+        "footer": "Tu privacidad bajo tu control."
+      },
       "noHistory": "No hay historial de búsqueda para mostrar",
       "openButton": "Mi Historial",
       "suggestionResults": "({totalResults} resultados)",
@@ -35,7 +39,7 @@
       "title": "Quizás te Interese"
     },
     "nextQueriesGroup": {
-      "message": "Los que buscaron <span class=\"x-title3\">\"{query}\"</span> también han visto:"
+      "message": "Los que buscaron {query} también han visto:"
     },
     "nextQueryPreview": {
       "message": "Los que buscaron {query} también han visto:",
@@ -74,7 +78,7 @@
       "showAside": "Ordenar y Filtrar"
     },
     "totalResults": {
-      "message": "{totalResults} resultados para <span class=\"x-title3\">{query}</span>"
+      "message": "{totalResults} resultados para {query}"
     },
     "sort": {
       "label": "Ordenar por",
@@ -91,10 +95,10 @@
       "addToCart": "AÑADIR AL CARRITO"
     },
     "spellcheck": {
-      "message": "No se han encontrado resultados para <span class=\"x-font-bold x-text-auxiliary-50 \">'{query}'</span>. Aquí tienes resultados para"
+      "message": "No se han encontrado resultados para '{query}'. Aquí tienes resultados para"
     },
     "noResults": {
-      "message": "<span>No se han encontrado resultados para <span class=\"x-font-bold \">\"{query}\"</span></span>Quizás te interesen estos productos"
+      "message": "No se han encontrado resultados para {query}Quizás te interesen estos productos"
     },
     "columnPicker": {
       "message": "Ver"
@@ -105,7 +109,7 @@
   },
   "mobile": {
     "nextQueriesGroup": {
-      "message": "Los que buscaron <span class=\"x-title3\">\"{query}\"</span> también han visto:"
+      "message": "Los que buscaron {query} también han visto:"
     },
     "nextQueryPreview": {
       "viewResults": "Ver todos"

--- a/src/i18n/messages/fr.messages.json
+++ b/src/i18n/messages/fr.messages.json
@@ -15,7 +15,11 @@
     "myHistory": {
       "title": "Mon histoire",
       "subtitle": "Ceci est la liste complète des requêtes d'historique",
-      "message": "<span>Ces données sont stockées localement. Juste dans votre appareil et ne voyagez jamais en dehors de celui-ci.</span><span>Vous pouvez désactiver les requêtes d'historique quand vous le souhaitez.</span><span class=\"x-title3\">Votre vie privée sous votre contrôle.</span>",
+      "message": {
+        "header": "Ces données sont stockées localement. Juste dans votre appareil et ne voyagez jamais en dehors de celui-ci.",
+        "body": "Vous pouvez désactiver les requêtes d'historique quand vous le souhaitez.",
+        "footer": "Votre vie privée sous votre contrôle."
+      },
       "noHistory": "Aucune activité d'historique à afficher",
       "openButton": "Mon histoire",
       "suggestionResults": "({totalResults} résultats)",
@@ -35,7 +39,7 @@
       "title": "Et Après"
     },
     "nextQueriesGroup": {
-      "message": "Ceux qui cherchaient <span class=\"x-title3\">\"{query}\"</span> également consulté:"
+      "message": "Ceux qui cherchaient {query} également consulté:"
     },
     "nextQueryPreview": {
       "message": "Ceux qui ont recherché {query} ont également consulté:",
@@ -77,7 +81,7 @@
       "showAside": "Trier et filtrer"
     },
     "totalResults": {
-      "message": "{totalResults} résultats pour <span class=\"x-title3\">{query}</span>"
+      "message": "{totalResults} résultats pour {query}"
     },
     "sort": {
       "label": "Trier par",
@@ -94,10 +98,10 @@
       "addToCart": "AJOUTER AU PANIER"
     },
     "spellcheck": {
-      "message": "Aucun résultat trouvé pour <span class=\"x-font-bold  x-text-auxiliary-50 \">'{query}'</span>. Nous vous montrons les résultats pour"
+      "message": "Aucun résultat trouvé pour '{query}'. Nous vous montrons les résultats pour"
     },
     "noResults": {
-      "message": "<span>Désolé mais il n'y a pas de résultats pour <span class=\"x-font-bold \">\"{query}\"</span></span>Vous pourriez être intéressé par ces produits"
+      "message": "Désolé mais il n'y a pas de résultats pour {query}Vous pourriez être intéressé par ces produits"
     },
     "columnPicker": {
       "message": "Voir"
@@ -108,7 +112,7 @@
   },
   "mobile": {
     "nextQueriesGroup": {
-      "message": "Ceux qui cherchaient <span class=\"x-title3\">\"{query}\"</span> également consulté:"
+      "message": "Ceux qui cherchaient {query} également consulté:"
     },
     "nextQueryPreview": {
       "viewResults": "Voir tout"

--- a/src/i18n/messages/pt.messages.json
+++ b/src/i18n/messages/pt.messages.json
@@ -15,7 +15,11 @@
     "myHistory": {
       "title": "Meu histórico",
       "subtitle": "Esse é seu histórico de buscas",
-      "message": "<span>Seus dados são salvos localmente. Ficam apenas em seu dispositivo e não são compartilhados externamente.</span><span> Você pode desativar o seu histórico de buscas sempre que desejar.</span><span class=\"x-title3\">Sua privacidade sob seu controle.</span>",
+      "message": {
+        "header": "Seus dados são salvos localmente. Ficam apenas em seu dispositivo e não são compartilhados externamente.",
+        "body": "Você pode desativar o seu histórico de buscas sempre que desejar.",
+        "footer": "Sua privacidade sob seu controle."
+      },
       "noHistory": "Não há histórico de buscas para mostrar",
       "openButton": "Meu histórico",
       "suggestionResults": "({totalResults} resultados)",
@@ -35,7 +39,7 @@
       "title": "Você Pode se Interessar"
     },
     "nextQueriesGroup": {
-      "message": "Aqueles que pesquisaram por <span class=\"x-title3\">\"{query}\"</span> também viram:"
+      "message": "Aqueles que pesquisaram por {query} também viram:"
     },
     "nextQueryPreview": {
       "message": "Os que buscaram por {query} também viram:",
@@ -74,7 +78,7 @@
       "showAside": "Ordenar e Filtrar"
     },
     "totalResults": {
-      "message": "{totalResults} resultados para <span class=\"x-title3\">{query}</span>"
+      "message": "{totalResults} resultados para {query}"
     },
     "sort": {
       "label": "Ordenar por",
@@ -91,10 +95,10 @@
       "addToCart": "ADICIONAR AO CARRINHO"
     },
     "spellcheck": {
-      "message": "Sem resultados encontrados para <span class=\"x-font-bold  x-text-auxiliary-50 \">'{query}'</span>. Aqui estão os resultados para"
+      "message": "Sem resultados encontrados para '{query}'. Aqui estão os resultados para"
     },
     "noResults": {
-      "message": "<span>Não encontramos resultados para<span class=\"x-font-bold \">\"{query}\"</span></span> Talvez você pode se interessar por esses produtos"
+      "message": "Não encontramos resultados para{query} Talvez você pode se interessar por esses produtos"
     },
     "columnPicker": {
       "message": "Ver"
@@ -105,7 +109,7 @@
   },
   "mobile": {
     "nextQueriesGroup": {
-      "message": "Os que buscaram <span class=\"x-title3\">\"{query}\"</span> também viram:"
+      "message": "Os que buscaram {query} também viram:"
     },
     "nextQueryPreview": {
       "viewResults": "Ver todos"

--- a/tests/e2e/cucumber/predictive-components.feature
+++ b/tests/e2e/cucumber/predictive-components.feature
@@ -39,6 +39,7 @@ Feature: Predictive components
     Given start page with "<view>" size view
     When  start button is clicked
     Given a "<list>" of queries already searched
+    And   an empty search-box
     When  focus is set on the search input
     And   history queries are displayed
     And   history query number <historyQueryItem> delete button is clicked
@@ -52,6 +53,7 @@ Feature: Predictive components
     Given start page with "<view>" size view
     When  start button is clicked
     Given a "<list>" of queries already searched
+    And   an empty search-box
     When  focus is set on the search input
     And   clear history queries button is clicked
     Then  no history queries are displayed

--- a/tests/e2e/cucumber/predictive-components.spec.ts
+++ b/tests/e2e/cucumber/predictive-components.spec.ts
@@ -1,4 +1,4 @@
-import { And, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 And('recommendations are displayed', () => {
   cy.getByDataTest('recommendation-item').should('have.length.at.least', 1);
@@ -63,9 +63,8 @@ Then('related tag {int} is displayed as not selected', (relatedTagItem: number) 
 });
 
 // Scenario 3
-And('a {string} of queries already searched', (list: string) => {
+Given('a {string} of queries already searched', (list: string) => {
   cy.searchQueries(...list.split(', '));
-  cy.clearSearchInput();
 });
 
 When('history query number {int} delete button is clicked', (historyQueryItem: number) => {
@@ -91,6 +90,10 @@ Then(
 );
 
 // Scenario 4
+And('an empty search-box', () => {
+  cy.clearSearchInput();
+});
+
 When('clear history queries button is clicked', () => {
   cy.getByDataTest('clear-history-queries').click();
 });


### PR DESCRIPTION
BREAKING CHANGE: Split `myHistory.message` translation into three different parts: `header`, `body` and `footer`.

EX-6928
