### PR TITLE
feat(history-queries): hide history queries when there are none with results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@empathyco/x-adapter": "^8.0.0-alpha.17",
         "@empathyco/x-adapter-platform": "^1.0.0-alpha.52",
         "@empathyco/x-archetype-utils": "^0.1.0-alpha.7",
-        "@empathyco/x-components": "^3.0.0-alpha.268",
+        "@empathyco/x-components": "^3.0.0-alpha.274",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.26",
         "@empathyco/x-types": "^10.0.0-alpha.50",
         "@empathyco/x-utils": "^1.0.0-alpha.12",
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@empathyco/x-components": {
-      "version": "3.0.0-alpha.272",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.272.tgz",
-      "integrity": "sha512-tTQtUE8zTSHTPVs4EsdZoiJh/eYi5G4klP329RbomIs4D+LikWB0bm0QsFRhZwvbbTWubZKo0CT1/WJfZ/ZYLg==",
+      "version": "3.0.0-alpha.274",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.274.tgz",
+      "integrity": "sha512-nRg2vPmGeeVP8S5Rzy1uYBH3U1fMdjF2Cd27c+Ba21687sFsevFgQyEzYNuBhxT0Rruz/mxzXb6UMOWBvAYfVA==",
       "dependencies": {
         "@empathyco/x-adapter": "^8.0.0-alpha.18",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.27",
@@ -28913,9 +28913,9 @@
       }
     },
     "@empathyco/x-components": {
-      "version": "3.0.0-alpha.272",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.272.tgz",
-      "integrity": "sha512-tTQtUE8zTSHTPVs4EsdZoiJh/eYi5G4klP329RbomIs4D+LikWB0bm0QsFRhZwvbbTWubZKo0CT1/WJfZ/ZYLg==",
+      "version": "3.0.0-alpha.274",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.274.tgz",
+      "integrity": "sha512-nRg2vPmGeeVP8S5Rzy1uYBH3U1fMdjF2Cd27c+Ba21687sFsevFgQyEzYNuBhxT0Rruz/mxzXb6UMOWBvAYfVA==",
       "requires": {
         "@empathyco/x-adapter": "^8.0.0-alpha.18",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@empathyco/x-adapter": "^8.0.0-alpha.17",
         "@empathyco/x-adapter-platform": "^1.0.0-alpha.52",
         "@empathyco/x-archetype-utils": "^0.1.0-alpha.13",
-        "@empathyco/x-components": "^3.0.0-alpha.268",
+        "@empathyco/x-components": "^3.0.0-alpha.280",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.26",
         "@empathyco/x-types": "^10.0.0-alpha.50",
         "@empathyco/x-utils": "^1.0.0-alpha.12",
@@ -2035,9 +2035,9 @@
       }
     },
     "node_modules/@empathyco/x-adapter": {
-      "version": "8.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.18.tgz",
-      "integrity": "sha512-shGq/w0wreVH4w8gs6/rCxkbjzoNCsH4UDKgdTF+SnLfMNIqu/POZpih0R68XqheyUDev7uFY2ApQdgDO9cwpw==",
+      "version": "8.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.19.tgz",
+      "integrity": "sha512-mw9njD3uCrwPZYpkIuZ+ejl19kJBO9ZM60/hAxSvGtyXJhudS+orVL+fd0KCO8aUK0tyu4x3Tid4wv/LLrja2Q==",
       "dependencies": {
         "@empathyco/x-deep-merge": "^1.3.0-alpha.27",
         "@empathyco/x-utils": "^1.0.0-alpha.13",
@@ -2083,20 +2083,20 @@
       }
     },
     "node_modules/@empathyco/x-components": {
-      "version": "3.0.0-alpha.274",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.274.tgz",
-      "integrity": "sha512-nRg2vPmGeeVP8S5Rzy1uYBH3U1fMdjF2Cd27c+Ba21687sFsevFgQyEzYNuBhxT0Rruz/mxzXb6UMOWBvAYfVA==",
+      "version": "3.0.0-alpha.280",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.280.tgz",
+      "integrity": "sha512-HUIf0u/qk5iTqdJ5IZOQ5rmh05apfd94rPgnFMLyxLDgb1fYk90wMKAjLsXvkE3mGmQzZcap94o2H/CnDfr9TA==",
       "dependencies": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.18",
+        "@empathyco/x-adapter": "^8.0.0-alpha.19",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.27",
         "@empathyco/x-logger": "^1.2.0-alpha.5",
         "@empathyco/x-storage-service": "^2.0.0-alpha.5",
-        "@empathyco/x-types": "^10.0.0-alpha.51",
+        "@empathyco/x-types": "^10.0.0-alpha.53",
         "@empathyco/x-utils": "^1.0.0-alpha.13",
         "@vue/devtools-api": "~6.4.5",
         "rxjs": "~7.8.0",
         "tslib": "~2.4.1",
-        "vue-class-component": "~7.1.0",
+        "vue-class-component": "~7.2.6",
         "vue-global-events": "~1.2.1",
         "vue-property-decorator": "~8.3.0",
         "vue-runtime-helpers": "~1.1.2"
@@ -2113,6 +2113,14 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@empathyco/x-components/node_modules/vue-class-component": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
+      "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
+      }
     },
     "node_modules/@empathyco/x-deep-merge": {
       "version": "1.3.0-alpha.27",
@@ -2217,11 +2225,11 @@
       }
     },
     "node_modules/@empathyco/x-types": {
-      "version": "10.0.0-alpha.51",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.51.tgz",
-      "integrity": "sha512-otxg2VTHW8s/l78XnQgtctHh8FayHVZa3c0eUr8h6dmtrxuE9ry93uLJBd9sMOS9n5vYZ6YBvN6+Ey4/8Z0mRw==",
+      "version": "10.0.0-alpha.53",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.53.tgz",
+      "integrity": "sha512-o8mPPrs/aaLHlEhRfd1/VDE3CxNLLkA3Fj8NANtCgth8mpHQ85Mt+RmLQN4WwnbR6yJt+aKnCuRRaxxOZ/owag==",
       "dependencies": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.18",
+        "@empathyco/x-adapter": "^8.0.0-alpha.19",
         "tslib": "~2.4.1"
       },
       "engines": {
@@ -28886,9 +28894,9 @@
       }
     },
     "@empathyco/x-adapter": {
-      "version": "8.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.18.tgz",
-      "integrity": "sha512-shGq/w0wreVH4w8gs6/rCxkbjzoNCsH4UDKgdTF+SnLfMNIqu/POZpih0R68XqheyUDev7uFY2ApQdgDO9cwpw==",
+      "version": "8.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.19.tgz",
+      "integrity": "sha512-mw9njD3uCrwPZYpkIuZ+ejl19kJBO9ZM60/hAxSvGtyXJhudS+orVL+fd0KCO8aUK0tyu4x3Tid4wv/LLrja2Q==",
       "requires": {
         "@empathyco/x-deep-merge": "^1.3.0-alpha.27",
         "@empathyco/x-utils": "^1.0.0-alpha.13",
@@ -28923,20 +28931,20 @@
       }
     },
     "@empathyco/x-components": {
-      "version": "3.0.0-alpha.274",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.274.tgz",
-      "integrity": "sha512-nRg2vPmGeeVP8S5Rzy1uYBH3U1fMdjF2Cd27c+Ba21687sFsevFgQyEzYNuBhxT0Rruz/mxzXb6UMOWBvAYfVA==",
+      "version": "3.0.0-alpha.280",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.280.tgz",
+      "integrity": "sha512-HUIf0u/qk5iTqdJ5IZOQ5rmh05apfd94rPgnFMLyxLDgb1fYk90wMKAjLsXvkE3mGmQzZcap94o2H/CnDfr9TA==",
       "requires": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.18",
+        "@empathyco/x-adapter": "^8.0.0-alpha.19",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.27",
         "@empathyco/x-logger": "^1.2.0-alpha.5",
         "@empathyco/x-storage-service": "^2.0.0-alpha.5",
-        "@empathyco/x-types": "^10.0.0-alpha.51",
+        "@empathyco/x-types": "^10.0.0-alpha.53",
         "@empathyco/x-utils": "^1.0.0-alpha.13",
         "@vue/devtools-api": "~6.4.5",
         "rxjs": "~7.8.0",
         "tslib": "~2.4.1",
-        "vue-class-component": "~7.1.0",
+        "vue-class-component": "~7.2.6",
         "vue-global-events": "~1.2.1",
         "vue-property-decorator": "~8.3.0",
         "vue-runtime-helpers": "~1.1.2"
@@ -28946,6 +28954,11 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
           "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "vue-class-component": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
+          "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w=="
         }
       }
     },
@@ -29025,11 +29038,11 @@
       }
     },
     "@empathyco/x-types": {
-      "version": "10.0.0-alpha.51",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.51.tgz",
-      "integrity": "sha512-otxg2VTHW8s/l78XnQgtctHh8FayHVZa3c0eUr8h6dmtrxuE9ry93uLJBd9sMOS9n5vYZ6YBvN6+Ey4/8Z0mRw==",
+      "version": "10.0.0-alpha.53",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.53.tgz",
+      "integrity": "sha512-o8mPPrs/aaLHlEhRfd1/VDE3CxNLLkA3Fj8NANtCgth8mpHQ85Mt+RmLQN4WwnbR6yJt+aKnCuRRaxxOZ/owag==",
       "requires": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.18",
+        "@empathyco/x-adapter": "^8.0.0-alpha.19",
         "tslib": "~2.4.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@empathyco/x-adapter": "^8.0.0-alpha.17",
     "@empathyco/x-adapter-platform": "^1.0.0-alpha.52",
     "@empathyco/x-archetype-utils": "^0.1.0-alpha.13",
-    "@empathyco/x-components": "^3.0.0-alpha.268",
+    "@empathyco/x-components": "^3.0.0-alpha.280",
     "@empathyco/x-deep-merge": "^1.3.0-alpha.26",
     "@empathyco/x-types": "^10.0.0-alpha.50",
     "@empathyco/x-utils": "^1.0.0-alpha.12",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@empathyco/x-adapter": "^8.0.0-alpha.17",
     "@empathyco/x-adapter-platform": "^1.0.0-alpha.52",
     "@empathyco/x-archetype-utils": "^0.1.0-alpha.7",
-    "@empathyco/x-components": "^3.0.0-alpha.268",
+    "@empathyco/x-components": "^3.0.0-alpha.274",
     "@empathyco/x-deep-merge": "^1.3.0-alpha.26",
     "@empathyco/x-types": "^10.0.0-alpha.50",
     "@empathyco/x-utils": "^1.0.0-alpha.12",

--- a/src/components/predictive-layer/predictive-layer.vue
+++ b/src/components/predictive-layer/predictive-layer.vue
@@ -44,7 +44,10 @@
           <SettingsIcon class="x-icon--l" />
         </BaseIdModalOpen>
         <div v-if="showHistoryQueries" class="x-list x-list--gap-02">
-          <div v-if="!$x.query.searchBox" class="x-list x-list--horizontal x-list--align-center">
+          <div
+            v-if="!$x.query.searchBox && $x.historyQueriesWithResults.length"
+            class="x-list x-list--horizontal x-list--align-center"
+          >
             <h1 class="x-title4 x-title4-sm x-uppercase x-list__item--expand">
               {{ $t('historyQueries.title') }}
             </h1>

--- a/src/components/predictive-layer/predictive-layer.vue
+++ b/src/components/predictive-layer/predictive-layer.vue
@@ -237,7 +237,7 @@
     }
 
     public get showHistoryQueries(): boolean {
-      return this.$x.historyQueries.length > 0;
+      return this.$x.historyQueriesWithResults.length > 0;
     }
 
     public get showQuerySuggestions(): boolean {

--- a/src/components/predictive-layer/predictive-layer.vue
+++ b/src/components/predictive-layer/predictive-layer.vue
@@ -1,5 +1,5 @@
 <template>
-  <Empathize v-if="showEmpathize" :animation="empathizeAnimation" class="x-list">
+  <Empathize :animation="empathizeAnimation" class="x-list">
     <BaseKeyboardNavigation
       class="x-row x-row--gap-06 x-row--align-start"
       :navigationHijacker="navigationHijacker"
@@ -22,7 +22,7 @@
       </IdentifierResults>
 
       <div
-        v-else
+        v-else-if="showEmpathize"
         class="x-row__item x-list x-padding--05"
         :class="[
           $x.query.searchBox
@@ -258,7 +258,6 @@
 
     public get showEmpathize(): boolean {
       return (
-        this.showIdentifierResults ||
         this.showHistoryQueries ||
         this.showQuerySuggestions ||
         this.showNextQueries ||

--- a/tests/e2e/cucumber/predictive-components.feature
+++ b/tests/e2e/cucumber/predictive-components.feature
@@ -46,7 +46,7 @@ Feature: Predictive components
     Then  the deleted history query is removed from history queries
     Examples:
       | list               | historyQueryItem | view        |
-      | shirt              | 0                | macbook-13  |
+      | shirt, shoe, skirt | 0                | macbook-13  |
       | shirt, shoe, skirt | 0                | iphone-x    |
 
   Scenario Outline: 4. Clear all history queries

--- a/tests/e2e/cucumber/predictive-components.feature
+++ b/tests/e2e/cucumber/predictive-components.feature
@@ -46,7 +46,7 @@ Feature: Predictive components
     Then  the deleted history query is removed from history queries
     Examples:
       | list               | historyQueryItem | view        |
-      | shirt, shoe, skirt | 0                | macbook-13  |
+      | shirt              | 0                | macbook-13  |
       | shirt, shoe, skirt | 0                | iphone-x    |
 
   Scenario Outline: 4. Clear all history queries


### PR DESCRIPTION
I have moved the condition to show the predictive layer from the `Empathize` component to the `div` containing the suggestions because the `Empathize` already has some logic to hide the predictive layer if it doesn't have content.

This fixes the behaviour where the `Empathize` is not displayed after clearing a query with no results and a history queries test that was failing occasionally because the `Empathize` was closed and Cypress couldn't get the history queries elements.

EX-7720