### PR TITLE
feat(styles) Archetype recurring changes

### DIFF
--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -4,11 +4,15 @@
 
     <!-- TODO: Remove the x-max-h and the tailwind important when removing the old DS styles -->
     <BaseColumnPickerList
-      v-slot="{ column }"
+      v-slot="{ column, isSelected }"
       :columns="values"
       buttonClass="!x-button-sm x-button-lead x-button-square x-button-ghost x-max-h-32"
     >
-      <component :is="icon(column)" class="x-icon--l" />
+      <component
+        :is="icon(column)"
+        class="x-icon--l"
+        :class="{ 'x-text-neutral-90': isSelected }"
+      />
     </BaseColumnPickerList>
   </div>
 </template>

--- a/src/components/search/desktop-aside.vue
+++ b/src/components/search/desktop-aside.vue
@@ -5,7 +5,7 @@
         x-list x-list--horizontal x-list--align-center
         x-border-width--bottom-01
         x-border-color--neutral-10
-        x-padding--06 x-padding--right-09 x-padding--left-08
+        x-padding--06 x-padding--right-07 x-padding--left-08
       "
     >
       <span class="x-title2 x-margin--right-auto">
@@ -15,7 +15,7 @@
         <CrossTinyIcon class="x-icon--l" />
       </BaseIdModalClose>
     </div>
-    <div class="x-scroll x-list__item--expand x-padding--08 x-padding--top-00">
+    <div class="x-scroll x-list__item--expand x-padding--08 x-padding--top-00 x-padding--right-06">
       <Sort />
       <CustomFacets v-if="$x.totalResults > 0" />
     </div>

--- a/src/components/search/mobile-aside.vue
+++ b/src/components/search/mobile-aside.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="$x.totalResults > 0" class="x-list x-list--vertical x-list__item--expand">
-    <BaseScroll class="x-list__item--expand x-padding--05">
+    <BaseScroll class="x-list__item--expand x-padding--05 x-padding--top-00" :resetOnChange="false">
       <Sort />
       <CustomFacets />
     </BaseScroll>

--- a/src/components/search/sort.vue
+++ b/src/components/search/sort.vue
@@ -4,15 +4,16 @@
     class="x-border-width--bottom-01 x-border-width--00 x-border-color--neutral-95"
   >
     <template #header>
-      <span class="x-title3 x-padding--bottom-02">
+      <span class="x-title3">
         {{ $t('sort.label') }}
       </span>
-      {{ $t(`sort.values.${$x.selectedSort || 'default'}`) }}
+      <span>{{ $t(`sort.values.${$x.selectedSort || 'default'}`) }}</span>
     </template>
     <template #default>
       <SortList
         v-if="$x.totalResults"
-        class="x-list x-list--vertical x-list--align-start x-list--gap-06 x-padding--bottom-05"
+        class="x-list x-list--vertical x-list--align-start x-padding--bottom-07"
+        :class="$x.device === 'mobile' ? 'x-list--gap-07' : 'x-list--gap-06'"
         :items="sortValues"
       >
         <template #default="{ item, isSelected }">

--- a/src/design-system/tokens.scss
+++ b/src/design-system/tokens.scss
@@ -73,7 +73,7 @@
   --x-size-font-facet-default: 14px;
 
   // Filters
-  --x-size-padding-top-filter-default: var(--x-size-base-0);
+  --x-size-padding-top-filter-default: 0px;
   --x-size-padding-bottom-filter-default: var(--x-size-base-06);
   --x-size-padding-left-filter-default: var(--x-size-base-02);
 
@@ -159,7 +159,7 @@
     --x-size-padding-top-suggestion-group-default: var(--x-size-base-04);
 
     // Sliding Panel
-    --x-size-width-sliding-panel-gradient: var(--x-size-base-00);
+    --x-size-width-sliding-panel-gradient: 0px;
 
     // Typography
     --x-size-font-title1: var(--x-size-font-base-l);

--- a/src/design-system/tokens.scss
+++ b/src/design-system/tokens.scss
@@ -132,7 +132,7 @@
 
   .x-mobile {
     // Grid
-    --x-size-gap-grid: var(--x-size-base-03);
+    --x-size-gap-grid: var(--x-size-base-05) var(--x-size-base-03);
     --x-size-padding-grid: var(--x-size-base-05);
 
     // Result

--- a/src/design-system/tokens.scss
+++ b/src/design-system/tokens.scss
@@ -73,18 +73,26 @@
   --x-size-font-facet-default: 14px;
 
   // Filters
-  --x-size-padding-top-filter-default: var(--x-size-base-05);
-  --x-size-padding-bottom-filter-default: var(--x-size-base-05);
+  --x-size-padding-top-filter-default: var(--x-size-base-0);
+  --x-size-padding-bottom-filter-default: var(--x-size-base-06);
   --x-size-padding-left-filter-default: var(--x-size-base-02);
 
-  // Options list
+  .x-filter {
+    align-items: center;
+  }
 
+  // Options list
   --x-size-padding-right-option-list-button-default: var(--x-size-base-05);
   --x-size-padding-left-option-list-button-default: var(--x-size-base-05);
   .x-facet {
     .x-option-list__item {
       --x-size-border-width-right-option-list-item-default: 0px;
+      --x-size-padding-left-option-list-button-default: 0px;
     }
+  }
+
+  .x-header-toggle-panel__header {
+    align-items: center;
   }
 
   // Modal overlay
@@ -170,5 +178,9 @@
       --x-size-padding-left-suggestion-group-default: var(--x-size-base-05);
       --x-size-padding-right-suggestion-group-default: var(--x-size-base-05);
     }
+
+    // Filters
+    --x-size-padding-top-filter-default: var(--x-size-base-02);
+    --x-size-padding-bottom-filter-default: var(--x-size-base-07);
   }
 }

--- a/src/i18n/messages.types.ts
+++ b/src/i18n/messages.types.ts
@@ -48,6 +48,9 @@ export interface Messages {
     totalResults: string;
     viewResults: string;
   };
+  identifierResults: {
+    title: string;
+  };
   recommendations: {
     title: string;
   };

--- a/src/i18n/messages/es.messages.json
+++ b/src/i18n/messages/es.messages.json
@@ -47,6 +47,9 @@
       "totalResults": "({totalResults})",
       "viewResults": "Ver todos los resultados"
     },
+    "identifierResults": {
+      "title": "Búsqueda SKU"
+    },
     "recommendations": {
       "title": "Top Clicked"
     },

--- a/src/i18n/messages/pt.messages.json
+++ b/src/i18n/messages/pt.messages.json
@@ -47,6 +47,9 @@
       "totalResults": "({totalResults})",
       "viewResults": "Ver todos os resultados"
     },
+    "identifierResults": {
+      "title": "Pesquisa de SKU"
+    },
     "recommendations": {
       "title": "Mais clicados"
     },


### PR DESCRIPTION
EX-7275

There is some stuff in the list that was already fixed. Here is the list of things applied: 

- Change grid mobile token
- Column picker inside toolbar: differentiate selected from not selected.
- Add the identifier result’s title translation key everywhere missing
- Mobile aside & desktop aside spacings
- Sort&Filter lists spacings

Take in account: not doing anything inside predictive as there's a PR opened that will fix some stuff

[EX-7224]: https://searchbroker.atlassian.net/browse/EX-7224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ