### PR TITLE
feat: Implement XDS product image in archetype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@empathyco/x-adapter": "^8.0.0-alpha.17",
         "@empathyco/x-adapter-platform": "^1.0.0-alpha.58",
         "@empathyco/x-archetype-utils": "^0.1.0-alpha.13",
-        "@empathyco/x-components": "^3.0.0-alpha.286",
+        "@empathyco/x-components": "^3.0.0-alpha.296",
         "@empathyco/x-deep-merge": "^1.3.0-alpha.26",
         "@empathyco/x-types": "^10.0.0-alpha.50",
         "@empathyco/x-utils": "^1.0.0-alpha.13",
@@ -2074,11 +2074,11 @@
       }
     },
     "node_modules/@empathyco/x-adapter": {
-      "version": "8.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.21.tgz",
-      "integrity": "sha512-0nbuSpR+Ow3RN8jN7AuXj71fEI4syZELiiInCCaw1za9KWGkbMJO8ZgBDP9MAG8BPLvrM1I5hgznce01wvgSbg==",
+      "version": "8.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.22.tgz",
+      "integrity": "sha512-08VDR1sC2jsJ94FymGOx6ryhnslz2JJED0GGz3gEZnN2b/GPT5ooJTQf/+wSq/v7lrIS7hiqsMdlJlB2wx/aSQ==",
       "dependencies": {
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.28",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.29",
         "@empathyco/x-utils": "^1.0.0-alpha.14",
         "tslib": "~2.4.1"
       },
@@ -2127,15 +2127,15 @@
       }
     },
     "node_modules/@empathyco/x-components": {
-      "version": "3.0.0-alpha.291",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.291.tgz",
-      "integrity": "sha512-+1VY+cAEMdgt2lJvbkOeqX+rLRzck/bj9uqG1Xz5eGAcPBIirRb9f5hSU9HfZZqRl3MSVnChordZtoLOm685Kg==",
+      "version": "3.0.0-alpha.296",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.296.tgz",
+      "integrity": "sha512-HD/lbUwarUHBgtIYnC91bSPsd0xBbVAgDg3oa2cned3GmMyoOb5TSzr/fOfFFnvGLmrbQRygZuIY2bIzlIY0nQ==",
       "dependencies": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.21",
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.28",
+        "@empathyco/x-adapter": "^8.0.0-alpha.22",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.29",
         "@empathyco/x-logger": "^1.2.0-alpha.6",
         "@empathyco/x-storage-service": "^2.0.0-alpha.6",
-        "@empathyco/x-types": "^10.0.0-alpha.55",
+        "@empathyco/x-types": "^10.0.0-alpha.56",
         "@empathyco/x-utils": "^1.0.0-alpha.14",
         "@vue/devtools-api": "~6.4.5",
         "rxjs": "~7.8.0",
@@ -2167,9 +2167,9 @@
       }
     },
     "node_modules/@empathyco/x-deep-merge": {
-      "version": "1.3.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-deep-merge/-/x-deep-merge-1.3.0-alpha.28.tgz",
-      "integrity": "sha512-RBj0POWfjrcSsRoqt0vgvu3mvGJ1wzBQq+RxhDyxrOZEx8cXRG+DAhbLA2F9fYNm1ykv4DjxfQIovfaRCFeDOA==",
+      "version": "1.3.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-deep-merge/-/x-deep-merge-1.3.0-alpha.29.tgz",
+      "integrity": "sha512-xleVY1/KIsLFh/3PYGaFsSe8IfpiDW0tBnDpw/vid5ShD+UyWrc+nnkPjUc3eQweHbfmsVpvl4W7iGUlxzJHwA==",
       "dependencies": {
         "@empathyco/x-utils": "^1.0.0-alpha.14",
         "tslib": "~2.4.1"
@@ -2269,11 +2269,11 @@
       }
     },
     "node_modules/@empathyco/x-types": {
-      "version": "10.0.0-alpha.55",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.55.tgz",
-      "integrity": "sha512-8YlZi3jRGKTnlyt5KKkBxzH1Jvm6r2HMcTM9FjgP1Tq6zkmRBIb/6y1uzpTlTbYQdk4iUsFleQDim5Uh1Rs4pg==",
+      "version": "10.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.56.tgz",
+      "integrity": "sha512-0F2GUU7XtfhMgn9TPmbpmBcTCFUNfouQIUkF5SGATzqvFtv/QwCaBtYQjS6eXtlViP0knfpZ6k2Ggp5t6tEQTA==",
       "dependencies": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.21",
+        "@empathyco/x-adapter": "^8.0.0-alpha.22",
         "tslib": "~2.4.1"
       },
       "engines": {
@@ -29019,11 +29019,11 @@
       }
     },
     "@empathyco/x-adapter": {
-      "version": "8.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.21.tgz",
-      "integrity": "sha512-0nbuSpR+Ow3RN8jN7AuXj71fEI4syZELiiInCCaw1za9KWGkbMJO8ZgBDP9MAG8BPLvrM1I5hgznce01wvgSbg==",
+      "version": "8.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-adapter/-/x-adapter-8.0.0-alpha.22.tgz",
+      "integrity": "sha512-08VDR1sC2jsJ94FymGOx6ryhnslz2JJED0GGz3gEZnN2b/GPT5ooJTQf/+wSq/v7lrIS7hiqsMdlJlB2wx/aSQ==",
       "requires": {
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.28",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.29",
         "@empathyco/x-utils": "^1.0.0-alpha.14",
         "tslib": "~2.4.1"
       },
@@ -29063,15 +29063,15 @@
       }
     },
     "@empathyco/x-components": {
-      "version": "3.0.0-alpha.291",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.291.tgz",
-      "integrity": "sha512-+1VY+cAEMdgt2lJvbkOeqX+rLRzck/bj9uqG1Xz5eGAcPBIirRb9f5hSU9HfZZqRl3MSVnChordZtoLOm685Kg==",
+      "version": "3.0.0-alpha.296",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-3.0.0-alpha.296.tgz",
+      "integrity": "sha512-HD/lbUwarUHBgtIYnC91bSPsd0xBbVAgDg3oa2cned3GmMyoOb5TSzr/fOfFFnvGLmrbQRygZuIY2bIzlIY0nQ==",
       "requires": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.21",
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.28",
+        "@empathyco/x-adapter": "^8.0.0-alpha.22",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.29",
         "@empathyco/x-logger": "^1.2.0-alpha.6",
         "@empathyco/x-storage-service": "^2.0.0-alpha.6",
-        "@empathyco/x-types": "^10.0.0-alpha.55",
+        "@empathyco/x-types": "^10.0.0-alpha.56",
         "@empathyco/x-utils": "^1.0.0-alpha.14",
         "@vue/devtools-api": "~6.4.5",
         "rxjs": "~7.8.0",
@@ -29095,9 +29095,9 @@
       }
     },
     "@empathyco/x-deep-merge": {
-      "version": "1.3.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-deep-merge/-/x-deep-merge-1.3.0-alpha.28.tgz",
-      "integrity": "sha512-RBj0POWfjrcSsRoqt0vgvu3mvGJ1wzBQq+RxhDyxrOZEx8cXRG+DAhbLA2F9fYNm1ykv4DjxfQIovfaRCFeDOA==",
+      "version": "1.3.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-deep-merge/-/x-deep-merge-1.3.0-alpha.29.tgz",
+      "integrity": "sha512-xleVY1/KIsLFh/3PYGaFsSe8IfpiDW0tBnDpw/vid5ShD+UyWrc+nnkPjUc3eQweHbfmsVpvl4W7iGUlxzJHwA==",
       "requires": {
         "@empathyco/x-utils": "^1.0.0-alpha.14",
         "tslib": "~2.4.1"
@@ -29170,11 +29170,11 @@
       }
     },
     "@empathyco/x-types": {
-      "version": "10.0.0-alpha.55",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.55.tgz",
-      "integrity": "sha512-8YlZi3jRGKTnlyt5KKkBxzH1Jvm6r2HMcTM9FjgP1Tq6zkmRBIb/6y1uzpTlTbYQdk4iUsFleQDim5Uh1Rs4pg==",
+      "version": "10.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-types/-/x-types-10.0.0-alpha.56.tgz",
+      "integrity": "sha512-0F2GUU7XtfhMgn9TPmbpmBcTCFUNfouQIUkF5SGATzqvFtv/QwCaBtYQjS6eXtlViP0knfpZ6k2Ggp5t6tEQTA==",
       "requires": {
-        "@empathyco/x-adapter": "^8.0.0-alpha.21",
+        "@empathyco/x-adapter": "^8.0.0-alpha.22",
         "tslib": "~2.4.1"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "devDependencies": {
         "@cypress/webpack-preprocessor": "~5.11.1",
         "@empathyco/eslint-plugin-x": "^2.0.0-alpha.21",
-        "@empathyco/x-tailwindcss": "^0.2.0-alpha.44",
+        "@empathyco/x-tailwindcss": "^0.2.0-alpha.54",
         "@empathyco/x-translations": "^1.1.0-alpha.30",
         "@rollup/plugin-commonjs": "~21.0.1",
         "@rollup/plugin-json": "~4.1.0",
@@ -2217,12 +2217,12 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@empathyco/x-tailwindcss": {
-      "version": "0.2.0-alpha.52",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-tailwindcss/-/x-tailwindcss-0.2.0-alpha.52.tgz",
-      "integrity": "sha512-5dWVF5f+5GJy4idUrg+vtP7+4DqL3S/PwaPC7RmPuYeJngKKzi8QXXPyR+reuulQX/iUKz9QRSUkQFExP7XPCw==",
+      "version": "0.2.0-alpha.54",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-tailwindcss/-/x-tailwindcss-0.2.0-alpha.54.tgz",
+      "integrity": "sha512-IqpaSfDcFL20AmmXpyx7R5t7xTc22JPi41ZKLnIL8L0qn2lIRrOK99fnfbjwAX1bhp0eCmIKa+cMmsP8+CKK7Q==",
       "dev": true,
       "dependencies": {
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.28",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.29",
         "@empathyco/x-utils": "^1.0.0-alpha.14",
         "tslib": "~2.4.1"
       },
@@ -29142,12 +29142,12 @@
       }
     },
     "@empathyco/x-tailwindcss": {
-      "version": "0.2.0-alpha.52",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-tailwindcss/-/x-tailwindcss-0.2.0-alpha.52.tgz",
-      "integrity": "sha512-5dWVF5f+5GJy4idUrg+vtP7+4DqL3S/PwaPC7RmPuYeJngKKzi8QXXPyR+reuulQX/iUKz9QRSUkQFExP7XPCw==",
+      "version": "0.2.0-alpha.54",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-tailwindcss/-/x-tailwindcss-0.2.0-alpha.54.tgz",
+      "integrity": "sha512-IqpaSfDcFL20AmmXpyx7R5t7xTc22JPi41ZKLnIL8L0qn2lIRrOK99fnfbjwAX1bhp0eCmIKa+cMmsP8+CKK7Q==",
       "dev": true,
       "requires": {
-        "@empathyco/x-deep-merge": "^1.3.0-alpha.28",
+        "@empathyco/x-deep-merge": "^1.3.0-alpha.29",
         "@empathyco/x-utils": "^1.0.0-alpha.14",
         "tslib": "~2.4.1"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "~5.11.1",
     "@empathyco/eslint-plugin-x": "^2.0.0-alpha.21",
-    "@empathyco/x-tailwindcss": "^0.2.0-alpha.44",
+    "@empathyco/x-tailwindcss": "^0.2.0-alpha.54",
     "@empathyco/x-translations": "^1.1.0-alpha.30",
     "@rollup/plugin-commonjs": "~21.0.1",
     "@rollup/plugin-json": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@empathyco/x-adapter": "^8.0.0-alpha.17",
     "@empathyco/x-adapter-platform": "^1.0.0-alpha.58",
     "@empathyco/x-archetype-utils": "^0.1.0-alpha.13",
-    "@empathyco/x-components": "^3.0.0-alpha.286",
+    "@empathyco/x-components": "^3.0.0-alpha.296",
     "@empathyco/x-deep-merge": "^1.3.0-alpha.26",
     "@empathyco/x-types": "^10.0.0-alpha.50",
     "@empathyco/x-utils": "^1.0.0-alpha.13",

--- a/src/components/results/result.vue
+++ b/src/components/results/result.vue
@@ -1,11 +1,7 @@
 <template>
   <MainScrollItem :item="result" tag="article" class="x-result">
     <BaseResultLink class="x-result__picture" :result="result">
-      <BaseResultImage
-        :result="result"
-        :loadAnimation="imageAnimation"
-        class="x-picture--fixed-ratio x-picture--zoom"
-      >
+      <BaseResultImage :result="result" :loadAnimation="imageAnimation" class="x-picture-zoom">
         <template #placeholder>
           <BasePlaceholderImage />
         </template>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
   // See https://github.com/empathyco/x/pull/655#discussion_r948923711
   corePlugins: [
     'alignItems',
-    'backgroundImage',
+    'backgroundColor',
     'display',
     'fontSize',
     'fontWeight',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,7 @@ module.exports = {
   // See https://github.com/empathyco/x/pull/655#discussion_r948923711
   corePlugins: [
     'alignItems',
+    'backgroundImage',
     'display',
     'fontSize',
     'fontWeight',


### PR DESCRIPTION
EX-7837

- implement XDS class, 
- update packages, 
- add `backgroundColor` plugin in tailwind to support `x-picture-overlay` variant

[Sliding panel PR](https://github.com/empathyco/x-archetype/pull/246) should be merged first and then update this branch with that changes. Currently, tagging tests are failing as the row gets unstyled and then the list of products can't be scrolled as expected.

Also, the [XDS use class instead of img tag PR](https://github.com/empathyco/x/pull/1035) should be merged first and then update the package version.

