### PR TITLE
bugfix: remove active element when deselecting RT

### DIFF
--- a/src/components/search/related-tags.vue
+++ b/src/components/search/related-tags.vue
@@ -36,7 +36,8 @@
     PlusIcon,
     SlidingPanel,
     StaggeredFadeAndSlide,
-    CuratedCheckIcon
+    CuratedCheckIcon,
+    use$x
   } from '@empathyco/x-components';
   import { RelatedTags } from '@empathyco/x-components/related-tags';
   import { defineComponent } from 'vue';
@@ -54,8 +55,14 @@
     },
 
     setup() {
+      const $x = use$x();
       const relatedTagsAnimation = StaggeredFadeAndSlide;
       const { isTouchable } = useDevice();
+
+      $x.on('UserDeselectedARelatedTag').subscribe(() => {
+        (document.activeElement as HTMLElement).blur();
+      });
+
       return {
         relatedTagsAnimation,
         isTouchable


### PR DESCRIPTION
## Motivation and context
Active element wasn't being removed after deselecting a related tag, causing it to look as hovered. 
This bug came out during Conforama setup thanks to the high contrast between colours used. 

Applying same solution as in Conforama.


## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](https://github.com/empathyco/x/blob/main/.github/contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
