### PR TITLE
feat: emit display click on semantic queries click

### DIFF
--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -20,7 +20,7 @@
               <ArrowRightIcon class="x-icon-lg" />
             </BaseEventButton>
           </template>
-          <DisplayClickProvider feature="semantics">
+          <DisplayClickProvider resultFeature="semantics">
             <div class="x-flex x-gap-16 x-pt-16 max-desktop:x-px-16">
               <Result
                 v-for="result in results"

--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -20,14 +20,16 @@
               <ArrowRightIcon class="x-icon-lg" />
             </BaseEventButton>
           </template>
-          <div class="x-flex x-gap-16 x-pt-16 max-desktop:x-px-16">
-            <Result
-              v-for="result in results"
-              :key="result.id"
-              :result="result"
-              class="x-w-[calc(38vw-16px)] desktop:x-w-[216px]"
-            />
-          </div>
+          <DisplayClickProvider feature="semantics">
+            <div class="x-flex x-gap-16 x-pt-16 max-desktop:x-px-16">
+              <Result
+                v-for="result in results"
+                :key="result.id"
+                :result="result"
+                class="x-w-[calc(38vw-16px)] desktop:x-w-[216px]"
+              />
+            </div>
+          </DisplayClickProvider>
         </CustomSlidingPanel>
       </QueryPreviewList>
     </section>
@@ -41,9 +43,11 @@
   import { QueryPreviewList } from '@empathyco/x-components/queries-preview';
   import CustomSlidingPanel from '../custom-sliding-panel.vue';
   import Result from '../results/result.vue';
+  import DisplayClickProvider from './display-click-provider.vue';
 
   export default defineComponent({
     components: {
+      DisplayClickProvider,
       BaseEventButton,
       ArrowRightIcon,
       CustomSlidingPanel,

--- a/src/components/search/display-click-provider.vue
+++ b/src/components/search/display-click-provider.vue
@@ -1,0 +1,38 @@
+<template>
+  <NoElement>
+    <slot />
+  </NoElement>
+</template>
+
+<script lang="ts">
+  import { NoElement, ResultFeature, use$x } from '@empathyco/x-components';
+  import { computed, defineComponent, PropType, provide } from 'vue';
+
+  export default defineComponent({
+    components: {
+      NoElement
+    },
+    props: {
+      feature: {
+        type: String as PropType<ResultFeature>,
+        required: true
+      }
+    },
+    setup(props) {
+      const $x = use$x();
+
+      const displayClickMetadata = computed(() => ({
+        displayOriginalQuery: $x.query.search,
+        feature: props.feature
+      }));
+
+      provide('resultClickExtraEvents', ['UserClickedADisplayResult']);
+      provide('resultLinkMetadataPerEvent', {
+        UserClickedAResult: {
+          ignoreInModules: ['tagging']
+        },
+        UserClickedADisplayResult: displayClickMetadata.value
+      });
+    }
+  });
+</script>

--- a/src/components/search/display-click-provider.vue
+++ b/src/components/search/display-click-provider.vue
@@ -16,6 +16,10 @@
       feature: {
         type: String as PropType<ResultFeature>,
         required: true
+      },
+      ignoreResultClickEvent: {
+        type: Boolean,
+        default: true
       }
     },
     setup(props) {
@@ -28,10 +32,12 @@
 
       provide('resultClickExtraEvents', ['UserClickedADisplayResult']);
       provide('resultLinkMetadataPerEvent', {
-        UserClickedAResult: {
-          ignoreInModules: ['tagging']
-        },
-        UserClickedADisplayResult: displayClickMetadata.value
+        UserClickedADisplayResult: displayClickMetadata.value,
+        ...(props.ignoreResultClickEvent && {
+          UserClickedAResult: {
+            ignoreInModules: ['tagging']
+          }
+        })
       });
     }
   });

--- a/src/components/search/display-click-provider.vue
+++ b/src/components/search/display-click-provider.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-  import { NoElement, ResultFeature, use$x } from '@empathyco/x-components';
+  import { DisplayWireMetadata, NoElement, ResultFeature, use$x } from '@empathyco/x-components';
   import { computed, defineComponent, PropType, provide } from 'vue';
 
   export default defineComponent({
@@ -13,7 +13,7 @@
       NoElement
     },
     props: {
-      feature: {
+      resultFeature: {
         type: String as PropType<ResultFeature>,
         required: true
       },
@@ -25,9 +25,9 @@
     setup(props) {
       const $x = use$x();
 
-      const displayClickMetadata = computed(() => ({
+      const displayClickMetadata = computed<Partial<DisplayWireMetadata>>(() => ({
         displayOriginalQuery: $x.query.search,
-        feature: props.feature
+        feature: props.resultFeature
       }));
 
       provide('resultClickExtraEvents', ['UserClickedADisplayResult']);


### PR DESCRIPTION
[EMP-1067](https://searchbroker.atlassian.net/browse/EMP-1067)

## Motivation and context
We need to send the tagging event of display click when a semantic query is clicked.

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Search for `sofa` -> Click a semantic result -> check in the network that the event was sent with the correct payload -> search for `silla` -> Click a semantic result -> check in the network that the event was sent with the correct payload -> repeat ad infinitum -> regret your choices in life



[EMP-1067]: https://searchbroker.atlassian.net/browse/EMP-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ