### PR TITLE
test: review arquetype tests

### DIFF
--- a/tests/e2e/cucumber/common-steps.spec.ts
+++ b/tests/e2e/cucumber/common-steps.spec.ts
@@ -58,6 +58,7 @@ Then('a search request from {string} is done', (origin: string) => {
 
 // Results
 Then('related results are displayed', () => {
+  cy.getByDataTest('search-grid-result').eq(0).scrollIntoView();
   cy.getByDataTest('search-grid-result')
     .should('be.visible')
     .should('have.length.at.least', 1)

--- a/tests/e2e/cucumber/facets.feature
+++ b/tests/e2e/cucumber/facets.feature
@@ -74,7 +74,6 @@ Feature: Facets component
       | shirt | 2            | brand     | 1             | fit     | macbook-13  |
       | shirt | 2            | brand     | 1             | fit     | iphone-x    |
 
-  @skip
   Scenario Outline: 5. Hierarchical filters selection
     Given start page with "<view>" size view
     When  search bar is clicked

--- a/tests/e2e/cucumber/facets.feature
+++ b/tests/e2e/cucumber/facets.feature
@@ -74,6 +74,8 @@ Feature: Facets component
       | shirt | 2            | brand     | 1             | fit     | macbook-13  |
       | shirt | 2            | brand     | 1             | fit     | iphone-x    |
 
+    @skip
+  # TODO: Resume once the response returns hierarchical filters
   Scenario Outline: 5. Hierarchical filters selection
     Given start page with "<view>" size view
     When  search bar is clicked


### PR DESCRIPTION
## Motivation and context
Not many changes at the end. Child filters for hierarchical facets are not being returned, so test is kept as skipped until further development. 
Also, minor adjustment for `multipleinteraction` test: sometimes is was failing when looking for the result carts due to the presence of a banner.


<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](https://github.com/empathyco/x/blob/main/.github/contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
