### PR TITLE
fix(search): Products grid is shown even if there's a redirection

### DIFF
--- a/src/components/desktop/desktop-sub-header.vue
+++ b/src/components/desktop/desktop-sub-header.vue
@@ -9,7 +9,7 @@
         </div>
       </DesktopSearchboxAlign>
 
-      <div v-if="!$x.redirections.length && hasSearched">
+      <div v-if="hasSearched">
         <DesktopToolbar />
       </div>
       <div v-if="$x.totalResults > 0 && hasSearched && $x.selectedFilters.length">

--- a/src/components/desktop/desktop.vue
+++ b/src/components/desktop/desktop.vue
@@ -5,7 +5,7 @@
     <MainScroll class="x-flex x-flex-col">
       <Scroll id="main-scroll">
         <MaxDesktopWidthItem>
-          <div v-if="!$x.redirections.length && hasSearched">
+          <div v-if="hasSearched">
             <LocationProvider location="results">
               <SpellcheckMessage class="x-mb-16" data-test="spellcheck-message" />
             </LocationProvider>

--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -2,7 +2,7 @@
   <div v-if="hasSearched" class="x-flex x-flex-col">
     <Redirection />
 
-    <template v-if="!$x.redirections.length">
+    <template>
       <LocationProvider location="results">
         <Results />
       </LocationProvider>

--- a/src/components/mobile/mobile-sub-header.vue
+++ b/src/components/mobile/mobile-sub-header.vue
@@ -4,7 +4,7 @@
       <LocationProvider location="predictive_layer">
         <RelatedTags class="x-pb-16" />
       </LocationProvider>
-      <div v-if="$x.query.search && !$x.redirections.length">
+      <div v-if="$x.query.search">
         <MobileToolbar class="x-mb-16" />
       </div>
     </div>

--- a/src/components/mobile/mobile.vue
+++ b/src/components/mobile/mobile.vue
@@ -20,7 +20,7 @@
       <div class="x-flex x-flex-col">
         <MobileSubHeader :has-searched="hasSearched" />
 
-        <div v-if="$x.query.search && !$x.redirections.length" class="x-layout-item">
+        <div v-if="$x.query.search" class="x-layout-item">
           <LocationProvider location="results">
             <SpellcheckMessage class="x-mb-16" data-test="spellcheck-message" />
           </LocationProvider>


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Results grid have to be visible even if there is a redirection. I just deleted the v-if that checked if there was a redirection.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: https://searchbroker.atlassian.net/browse/EMP-1557

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
Manually checked that the results grid was displayed now even if there is a redirection

## Checklist:

- [ ] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
