### PR TITLE
fix: hide full empathize when there are no suggestions

### DIFF
--- a/src/components/predictive-layer/full-width-predictive.vue
+++ b/src/components/predictive-layer/full-width-predictive.vue
@@ -6,7 +6,7 @@
       :animation="empathizeAnimation"
       class="x-layout-item x-absolute x-z-[1] x-w-full x-bg-neutral-0 x-py-4"
     >
-      <MaxDesktopWidthItem>
+      <MaxDesktopWidthItem v-if="showEmpathize">
         <DesktopSearchboxAlign>
           <div class="x-layout-item">
             <div v-if="showEmpathize || showIdentifierResults" class="x-h-full x-py-12 x-pl-[17px]">


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Currently full predictive layer is open when there are no suggestions to display. Maybe in the archetype looks good but in several customers we have to change it each time.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-1642](https://searchbroker.atlassian.net/browse/EMP-1642)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Search for a query with no suggestions, for example: `print midi dress women`

## Checklist:

- [ ] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[EMP-1642]: https://searchbroker.atlassian.net/browse/EMP-1642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ