### PR TITLE
Fix Brand Recommendations on second time appearance

### DIFF
--- a/src/components/pre-search/custom-query-preview.vue
+++ b/src/components/pre-search/custom-query-preview.vue
@@ -1,6 +1,6 @@
 <template>
   <QueryPreviewList
-    v-if="!$x.query.searchBox && queriesPreviewInfo"
+    v-show="!$x.query.searchBox && queriesPreviewInfo"
     :debounceTimeMs="250"
     :queries="queries"
     #default="{ query, totalResults, results }"


### PR DESCRIPTION
[EMP-1707](https://searchbroker.atlassian.net/browse/EMP-1707)

Use `v-show` instead of `v-if` to prevent re-rendering


[EMP-1707]: https://searchbroker.atlassian.net/browse/EMP-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ