### PR TITLE
feat: better output directory for public files in build

### DIFF
--- a/build/instrumentation.build.js
+++ b/build/instrumentation.build.js
@@ -68,7 +68,7 @@ export function createConfig({
         })
       ),
       copy({
-        targets: [{ src: ['public/**', '!public/index.html'], dest: 'dist/' }]
+        targets: [{ src: ['public/**', '!public/index.html'], dest: '${output.dir}' }]
       }),
       // Resolving plugins
       replace(


### PR DESCRIPTION
## Motivation and context
Public files where copied to `dist` regardless of the actual output directory in the build. This PR changes it to take the actual directory.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Change the output and run the build, favicon and snippet config file should be in the actual output directory.
