### PR TITLE
chore: exclude x deps from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,10 @@
     {
       "matchPackageNames": ["vue-i18n"],
       "allowedVersions": "< 9"
+    },
+    {
+      "matchPackageNames": ["^@empathyco/*"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This PR prevents renovate from updating x related dependencies.