### PR TITLE
fix: Show SKU on desktop

### DIFF
--- a/src/components/predictive-layer/full-width-predictive.vue
+++ b/src/components/predictive-layer/full-width-predictive.vue
@@ -9,7 +9,7 @@
       <MaxDesktopWidthItem v-if="showEmpathize || showIdentifierResults">
         <DesktopSearchboxAlign>
           <div class="x-layout-item">
-            <div class="x-h-full x-py-12 x-pl-[17px]">
+            <div v-if="showEmpathize || showIdentifierResults" class="x-h-full x-py-12 x-pl-[17px]">
               <div class="x-block">
                 <BaseKeyboardNavigation
                   class="x-flex x-items-start x-gap-24"

--- a/src/components/predictive-layer/full-width-predictive.vue
+++ b/src/components/predictive-layer/full-width-predictive.vue
@@ -6,10 +6,10 @@
       :animation="empathizeAnimation"
       class="x-layout-item x-absolute x-z-[1] x-w-full x-bg-neutral-0 x-py-4"
     >
-      <MaxDesktopWidthItem v-if="showEmpathize">
+      <MaxDesktopWidthItem v-if="showEmpathize || showIdentifierResults">
         <DesktopSearchboxAlign>
           <div class="x-layout-item">
-            <div v-if="showEmpathize || showIdentifierResults" class="x-h-full x-py-12 x-pl-[17px]">
+            <div class="x-h-full x-py-12 x-pl-[17px]">
               <div class="x-block">
                 <BaseKeyboardNavigation
                   class="x-flex x-items-start x-gap-24"

--- a/src/components/predictive-layer/full-width-predictive.vue
+++ b/src/components/predictive-layer/full-width-predictive.vue
@@ -6,7 +6,7 @@
       :animation="empathizeAnimation"
       class="x-layout-item x-absolute x-z-[1] x-w-full x-bg-neutral-0 x-py-4"
     >
-      <MaxDesktopWidthItem v-if="showEmpathize || showIdentifierResults">
+      <MaxDesktopWidthItem>
         <DesktopSearchboxAlign>
           <div class="x-layout-item">
             <div v-if="showEmpathize || showIdentifierResults" class="x-h-full x-py-12 x-pl-[17px]">


### PR DESCRIPTION
If condition changed to enable showing SKU although no other predictive layer items are available
