### PR TITLE
fix: update experience control endpoint

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -61,13 +61,6 @@ semanticQueriesRequestSchema.$override<
   }
 });
 
-// TODO: Remove when the endpoint is propery created in the platform adapter
-// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-const experienceControlsAdapter = adapter.experienceControls.extends({
-  endpoint: 'https://config-service.internal.test.empathy.co/public/configs'
-});
-platformAdapter.experienceControls = experienceControlsAdapter;
-
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
 experienceControlsResponseSchema.$override<
   PlatformExperienceControlsResponse,


### PR DESCRIPTION
EMP-2720

Remove explicit override of the experience control URL

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
The experience control endpoint has been deployed in Staging environment, so we no longer need the override.

https://api.staging.empathy.co/config/v1/public/configs?service=xcontrols&instance=empathy

Note: This will not work from  PR preview, as the sudomain is x.test.empathy.co and the experience control ingress in Staging only accepts subdomain x.staging.empathy.co or localhost:8080

Run it locally to test.

## Motivation and context
To have a standard implementation

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](https://github.com/empathyco/x/blob/main/.github/contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
