### PR TITLE
feat: Use XControls in NextQueries and Layout

### DIFF
--- a/public/snippet-script.js
+++ b/public/snippet-script.js
@@ -82,7 +82,7 @@ window.initX = {
     {
       query: 'dress',
       title: 'Autumn dresses by Marni',
-      filters: ['brand:marni', 'collection:autumn - 2022']
+      filters: ['brand:marni', 'categoryIds:12fad53d7']
     },
     {
       query: 'belted legging',

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,11 +61,6 @@
       return this.snippetConfig.queriesPreview;
     }
 
-    @XProvide('experienceControls')
-    public get experienceControls(): QueryPreviewInfo[] | undefined {
-      return this.$store.state.x.experienceControls.controls;
-    }
-
     @Watch('snippetConfig.uiLang')
     syncLang(uiLang: string): void {
       this.$setLocale(uiLang);

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -6,8 +6,7 @@ import {
   recommendationsRequestSchema,
   resultSchema,
   semanticQueriesRequestSchema,
-  experienceControlsResponseSchema,
-  PlatformExperienceControlsResponse
+  experienceControlsResponseSchema
 } from '@empathyco/x-adapter-platform';
 import {
   ExperienceControlsResponse,
@@ -63,9 +62,10 @@ semanticQueriesRequestSchema.$override<
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
 experienceControlsResponseSchema.$override<
-  PlatformExperienceControlsResponse,
+  Partial<ExperienceControlsResponse>,
   Partial<ExperienceControlsResponse>
 >({
+  controls: ({ controls }) => controls,
   events: {
     SemanticQueriesConfigProvided: {
       maxItemsToRequest: 'controls.semanticQueries.numberOfCarousels',

--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -35,7 +35,7 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const { columns } = useXControlsHelpers({
+      const columns = useXControlsHelpers({
         controls: 'layout',
         prop: 'columnSelector',
         defaultValue: [4, 2]

--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -35,10 +35,14 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const columns = useExperienceControls().getControlFromPath('layout.columnSelector', [4, 2]);
+      const { getControlFromPath } = useExperienceControls();
+
+      const columns = computed(() =>
+        isMobile.value ? [2, 1] : getControlFromPath('layout.columnSelector', [4, 2])
+      );
 
       return {
-        values: computed(() => (isMobile.value ? [2, 1] : columns)),
+        values: columns,
         icons: { 1: 'Grid1ColIcon', 2: 'Grid2ColIcon', 4: 'Grid4ColIcon' }
       };
     }

--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -24,7 +24,7 @@
     Grid4ColIcon
   } from '@empathyco/x-components';
   import { useDevice } from '../composables/use-device.composable';
-  import { useExperienceControlsHelpers } from '../composables/use-experience-controls.composable';
+  import { useXControlsHelpers } from '../composables/use-experience-controls.composable';
 
   export default defineComponent({
     components: {
@@ -35,7 +35,7 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const { columns } = useExperienceControlsHelpers({
+      const { columns } = useXControlsHelpers({
         controls: 'layout',
         prop: 'columnSelector',
         defaultValue: [4, 2]

--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -36,7 +36,7 @@
     setup() {
       const { isMobile } = useDevice();
       const columns = useXControlsHelpers({
-        path: 'layout.columnSelector',
+        path: 'layout.columnSelector' as never,
         defaultValue: [4, 2]
       });
 

--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -36,8 +36,7 @@
     setup() {
       const { isMobile } = useDevice();
       const columns = useXControlsHelpers({
-        controls: 'layout',
-        prop: 'columnSelector',
+        path: 'layout.columnSelector',
         defaultValue: [4, 2]
       });
 

--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -24,6 +24,7 @@
     Grid4ColIcon
   } from '@empathyco/x-components';
   import { useDevice } from '../composables/use-device.composable';
+  import { useExperienceControlsHelpers } from '../composables/use-experience-controls.composable';
 
   export default defineComponent({
     components: {
@@ -34,8 +35,14 @@
     },
     setup() {
       const { isMobile } = useDevice();
+      const { columns } = useExperienceControlsHelpers({
+        controls: 'layout',
+        prop: 'columnSelector',
+        defaultValue: [4, 2]
+      });
+
       return {
-        values: computed(() => (isMobile.value ? [2, 1] : [4, 2])),
+        values: computed(() => (isMobile.value ? [2, 1] : columns)),
         icons: { 1: 'Grid1ColIcon', 2: 'Grid2ColIcon', 4: 'Grid4ColIcon' }
       };
     }

--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -24,7 +24,7 @@
     Grid4ColIcon
   } from '@empathyco/x-components';
   import { useDevice } from '../composables/use-device.composable';
-  import { useXControls } from '../composables/use-experience-controls.composable';
+  import { useExperienceControls } from '../composables/use-experience-controls.composable';
 
   export default defineComponent({
     components: {
@@ -35,10 +35,7 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const columns = useXControls({
-        path: 'layout.columnSelector' as never,
-        defaultValue: [4, 2]
-      });
+      const columns = useExperienceControls().getControlFromPath('layout.columnSelector', [4, 2]);
 
       return {
         values: computed(() => (isMobile.value ? [2, 1] : columns)),

--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -24,7 +24,7 @@
     Grid4ColIcon
   } from '@empathyco/x-components';
   import { useDevice } from '../composables/use-device.composable';
-  import { useXControlsHelpers } from '../composables/use-experience-controls.composable';
+  import { useXControls } from '../composables/use-experience-controls.composable';
 
   export default defineComponent({
     components: {
@@ -35,7 +35,7 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const columns = useXControlsHelpers({
+      const columns = useXControls({
         path: 'layout.columnSelector' as never,
         defaultValue: [4, 2]
       });

--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -61,13 +61,11 @@
     },
     setup() {
       const { isAnyQueryLoadedInPreview } = useQueriesPreview();
-      const maxItems = useExperienceControls().getControlFromPath(
-        'semanticQueries.resultsPerCarousels'
-      );
+      const { getControlFromPath } = useExperienceControls();
 
       return {
         isAnyQueryLoadedInPreview,
-        resultsPerCarousel: maxItems
+        resultsPerCarousel: getControlFromPath('semanticQueries.resultsPerCarousels')
       };
     }
   });

--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -46,7 +46,7 @@
   import { QueryPreviewList, useQueriesPreview } from '@empathyco/x-components/queries-preview';
   import CustomSlidingPanel from '../custom-sliding-panel.vue';
   import Result from '../results/result.vue';
-  import { useXControls } from '../../composables/use-experience-controls.composable';
+  import { useExperienceControls } from '../../composables/use-experience-controls.composable';
   import DisplayClickProvider from './display-click-provider.vue';
 
   export default defineComponent({
@@ -61,9 +61,9 @@
     },
     setup() {
       const { isAnyQueryLoadedInPreview } = useQueriesPreview();
-      const maxItems = useXControls({
-        path: 'semanticQueries.resultsPerCarousels' as never
-      });
+      const maxItems = useExperienceControls().getControlFromPath(
+        'semanticQueries.resultsPerCarousels'
+      );
 
       return {
         isAnyQueryLoadedInPreview,

--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -62,7 +62,7 @@
     setup() {
       const { isAnyQueryLoadedInPreview } = useQueriesPreview();
       const maxItems = useXControlsHelpers({
-        path: 'semanticQueries.resultsPerCarousels'
+        path: 'semanticQueries.resultsPerCarousels' as never
       });
 
       return {

--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -61,7 +61,7 @@
     },
     setup() {
       const { isAnyQueryLoadedInPreview } = useQueriesPreview();
-      const { maxItems } = useXControlsHelpers({
+      const maxItems = useXControlsHelpers({
         controls: 'semanticQueries',
         prop: 'resultsPerCarousels'
       });

--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -62,8 +62,7 @@
     setup() {
       const { isAnyQueryLoadedInPreview } = useQueriesPreview();
       const maxItems = useXControlsHelpers({
-        controls: 'semanticQueries',
-        prop: 'resultsPerCarousels'
+        path: 'semanticQueries.resultsPerCarousels'
       });
 
       return {

--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -41,12 +41,12 @@
 
 <script lang="ts">
   import { ArrowRightIcon } from '@empathyco/x-components';
-  import { computed, defineComponent, inject } from 'vue';
+  import { defineComponent } from 'vue';
   import { SemanticQueries, SemanticQuery } from '@empathyco/x-components/semantic-queries';
   import { QueryPreviewList, useQueriesPreview } from '@empathyco/x-components/queries-preview';
-  import { Dictionary } from '@empathyco/x-utils';
   import CustomSlidingPanel from '../custom-sliding-panel.vue';
   import Result from '../results/result.vue';
+  import { useXControlsHelpers } from '../../composables/use-experience-controls.composable';
   import DisplayClickProvider from './display-click-provider.vue';
 
   export default defineComponent({
@@ -61,19 +61,14 @@
     },
     setup() {
       const { isAnyQueryLoadedInPreview } = useQueriesPreview();
-
-      const experienceControls = inject<Dictionary>('experienceControls', {});
-
-      const resultsPerCarousel = computed(() => {
-        const resultsPerCarousel: number =
-          experienceControls.value?.controls?.semanticQueries?.resultsPerCarousels;
-
-        return resultsPerCarousel ?? undefined;
+      const { maxItems } = useXControlsHelpers({
+        controls: 'semanticQueries',
+        prop: 'resultsPerCarousels'
       });
 
       return {
         isAnyQueryLoadedInPreview,
-        resultsPerCarousel
+        resultsPerCarousel: maxItems
       };
     }
   });

--- a/src/components/search/custom-semantic-queries.vue
+++ b/src/components/search/custom-semantic-queries.vue
@@ -46,7 +46,7 @@
   import { QueryPreviewList, useQueriesPreview } from '@empathyco/x-components/queries-preview';
   import CustomSlidingPanel from '../custom-sliding-panel.vue';
   import Result from '../results/result.vue';
-  import { useXControlsHelpers } from '../../composables/use-experience-controls.composable';
+  import { useXControls } from '../../composables/use-experience-controls.composable';
   import DisplayClickProvider from './display-click-provider.vue';
 
   export default defineComponent({
@@ -61,7 +61,7 @@
     },
     setup() {
       const { isAnyQueryLoadedInPreview } = useQueriesPreview();
-      const maxItems = useXControlsHelpers({
+      const maxItems = useXControls({
         path: 'semanticQueries.resultsPerCarousels' as never
       });
 

--- a/src/components/search/results/custom-next-query-preview.vue
+++ b/src/components/search/results/custom-next-query-preview.vue
@@ -45,6 +45,7 @@
   import Result from '../../results/result.vue';
   import CustomSlidingPanel from '../../custom-sliding-panel.vue';
   import DisplayClickProvider from '../display-click-provider.vue';
+  import { useXControlsHelpers } from '../../../composables/use-experience-controls.composable';
 
   export default defineComponent({
     components: {
@@ -61,7 +62,12 @@
     },
     setup() {
       const { isTabletOrLess } = useDevice();
-      const maxItemsToRender = computed(() => (isTabletOrLess.value ? undefined : 5));
+      const maxItems = useXControlsHelpers({
+        path: 'nextQueries.maxItems' as never,
+        defaultValue: 5
+      });
+
+      const maxItemsToRender = computed(() => (isTabletOrLess.value ? undefined : maxItems));
       return {
         maxItemsToRender
       };

--- a/src/components/search/results/custom-next-query-preview.vue
+++ b/src/components/search/results/custom-next-query-preview.vue
@@ -45,7 +45,6 @@
   import Result from '../../results/result.vue';
   import CustomSlidingPanel from '../../custom-sliding-panel.vue';
   import DisplayClickProvider from '../display-click-provider.vue';
-  import { useXControlsHelpers } from '../../../composables/use-experience-controls.composable';
 
   export default defineComponent({
     components: {
@@ -62,12 +61,7 @@
     },
     setup() {
       const { isTabletOrLess } = useDevice();
-      const maxItems = useXControlsHelpers({
-        path: 'nextQueries.maxItems' as never,
-        defaultValue: 5
-      });
-
-      const maxItemsToRender = computed(() => (isTabletOrLess.value ? undefined : maxItems));
+      const maxItemsToRender = computed(() => (isTabletOrLess.value ? undefined : 5));
       return {
         maxItemsToRender
       };

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -76,12 +76,12 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const maxItems = useExperienceControls().getControlFromPath('nextQueries.maxItems', 1);
+      const { getControlFromPath } = useExperienceControls();
 
       return {
         staggeredFadeAndSlide: StaggeredFadeAndSlide,
         columns: isMobile.value ? 2 : 4,
-        maxNextQueriesPerGroup: maxItems
+        maxNextQueriesPerGroup: getControlFromPath('nextQueries.maxItems', 1)
       };
     }
   });

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -55,7 +55,7 @@
   import { NextQueriesList } from '@empathyco/x-components/next-queries';
   import { useDevice } from '../../../composables/use-device.composable';
   import Result from '../../results/result.vue';
-  import { useXControlsHelpers } from '../../../composables/use-experience-controls.composable';
+  import { useXControls } from '../../../composables/use-experience-controls.composable';
   import NextQueryPreview from './custom-next-query-preview.vue';
 
   export default defineComponent({
@@ -76,7 +76,7 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const maxItems = useXControlsHelpers({
+      const maxItems = useXControls({
         path: 'nextQueries.maxItems' as never,
         defaultValue: 1
       });

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -55,7 +55,7 @@
   import { NextQueriesList } from '@empathyco/x-components/next-queries';
   import { useDevice } from '../../../composables/use-device.composable';
   import Result from '../../results/result.vue';
-  import { useXControls } from '../../../composables/use-experience-controls.composable';
+  import { useExperienceControls } from '../../../composables/use-experience-controls.composable';
   import NextQueryPreview from './custom-next-query-preview.vue';
 
   export default defineComponent({
@@ -76,10 +76,7 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const maxItems = useXControls({
-        path: 'nextQueries.maxItems' as never,
-        defaultValue: 1
-      });
+      const maxItems = useExperienceControls().getControlFromPath('nextQueries.maxItems', 1);
 
       return {
         staggeredFadeAndSlide: StaggeredFadeAndSlide,

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -78,7 +78,7 @@
     setup() {
       const { isMobile } = useDevice();
       const { maxItems } = useExperienceControlsHelpers({
-        xmodule: 'nextQueries',
+        controls: 'nextQueries',
         prop: 'maxItems',
         defaultValue: 1
       });

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -55,8 +55,7 @@
   import { NextQueriesList } from '@empathyco/x-components/next-queries';
   import { useDevice } from '../../../composables/use-device.composable';
   import Result from '../../results/result.vue';
-  // eslint-disable-next-line max-len
-  import { useExperienceControlsHelpers } from '../../../composables/use-experience-controls.composable';
+  import { useXControlsHelpers } from '../../../composables/use-experience-controls.composable';
   import NextQueryPreview from './custom-next-query-preview.vue';
 
   export default defineComponent({
@@ -77,7 +76,7 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const { maxItems } = useExperienceControlsHelpers({
+      const { maxItems } = useXControlsHelpers({
         controls: 'nextQueries',
         prop: 'maxItems',
         defaultValue: 1

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -76,7 +76,7 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      const { maxItems } = useXControlsHelpers({
+      const maxItems = useXControlsHelpers({
         controls: 'nextQueries',
         prop: 'maxItems',
         defaultValue: 1

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -77,7 +77,7 @@
     setup() {
       const { isMobile } = useDevice();
       const maxItems = useXControlsHelpers({
-        path: 'nextQueries.maxItems',
+        path: 'nextQueries.maxItems' as never,
         defaultValue: 1
       });
 

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -77,8 +77,7 @@
     setup() {
       const { isMobile } = useDevice();
       const maxItems = useXControlsHelpers({
-        controls: 'nextQueries',
-        prop: 'maxItems',
+        path: 'nextQueries.maxItems',
         defaultValue: 1
       });
 

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -5,7 +5,7 @@
         <NextQueriesList
           :offset="24"
           :frequency="48"
-          :maxNextQueriesPerGroup="1"
+          :maxNextQueriesPerGroup="maxNextQueriesPerGroup"
           :showOnlyAfterOffset="$x.partialResults.length > 0"
         >
           <BaseVariableColumnGrid
@@ -55,6 +55,8 @@
   import { NextQueriesList } from '@empathyco/x-components/next-queries';
   import { useDevice } from '../../../composables/use-device.composable';
   import Result from '../../results/result.vue';
+  // eslint-disable-next-line max-len
+  import { useExperienceControlsHelpers } from '../../../composables/use-experience-controls.composable';
   import NextQueryPreview from './custom-next-query-preview.vue';
 
   export default defineComponent({
@@ -75,7 +77,17 @@
     },
     setup() {
       const { isMobile } = useDevice();
-      return { staggeredFadeAndSlide: StaggeredFadeAndSlide, columns: isMobile.value ? 2 : 4 };
+      const { maxItems } = useExperienceControlsHelpers({
+        xmodule: 'nextQueries',
+        prop: 'maxItems',
+        defaultValue: 1
+      });
+
+      return {
+        staggeredFadeAndSlide: StaggeredFadeAndSlide,
+        columns: isMobile.value ? 2 : 4,
+        maxNextQueriesPerGroup: maxItems
+      };
     }
   });
 </script>

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -1,5 +1,7 @@
-import { computed, ComputedRef, inject } from 'vue';
-import { Dictionary, getSafePropertyChain } from '@empathyco/x-utils';
+import { computed, ComputedRef } from 'vue';
+import { getSafePropertyChain } from '@empathyco/x-utils';
+import { ExperienceControlsState } from '@empathyco/x-components/experience-controls';
+import { useStore } from './use-store.composable';
 
 /**
  * Given a controls' object property chain, gets the experience controls values from the response.
@@ -13,12 +15,13 @@ export const useXControlsHelpers = ({
   path,
   defaultValue
 }: {
-  path: string;
+  path: never;
   defaultValue?: string | number | boolean | number[];
 }): ComputedRef => {
-  const experienceControls = inject<Dictionary>('experienceControls', {});
+  const experienceControls = (useStore('experienceControls') as unknown as ExperienceControlsState)
+    .controls.controls;
 
   return computed(() => {
-    return getSafePropertyChain(experienceControls.value.controls, path, defaultValue);
+    return getSafePropertyChain(experienceControls, path, defaultValue);
   });
 };

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -1,5 +1,5 @@
 import { computed, ComputedRef, inject } from 'vue';
-import { Dictionary } from '@empathyco/x-utils';
+import { Dictionary, getSafePropertyChain } from '@empathyco/x-utils';
 
 /**
  * Given a controls' object property chain, gets the experience controls values from the response.
@@ -18,10 +18,7 @@ export const useXControlsHelpers = ({
 }): ComputedRef => {
   const experienceControls = inject<Dictionary>('experienceControls', {});
 
-  const getByPath = function <T>(this: T, key: string): any {
-    return key.split('.').reduce((obj, prop) => (obj as any)[prop], this);
-  };
   return computed(() => {
-    return getByPath.call(experienceControls.value?.controls, path) ?? defaultValue;
+    return getSafePropertyChain(experienceControls.value.controls, path, defaultValue);
   });
 };

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -15,7 +15,7 @@ type ExperienceControlsHelpers = {
  *
  * @returns The experience controls utils.
  */
-export const useExperienceControlsHelpers = ({
+export const useXControlsHelpers = ({
   controls,
   prop,
   defaultValue

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -2,26 +2,26 @@ import { computed, ComputedRef, inject } from 'vue';
 import { Dictionary } from '@empathyco/x-utils';
 
 /**
- * Experience controls values per x-modules.
+ * Given a controls' object property chain, gets the experience controls values from the response.
  *
- * @param controls - The name of the xControls object that will be used.
- * @param prop - The name of the property value that will be set.
+ * @param path - The chain of properties in an xControls object.
  * @param defaultValue - A default value to set if xControls one is unavailable.
  *
- * @returns The experience controls utils.
+ * @returns The experience controls property value.
  */
 export const useXControlsHelpers = ({
-  controls,
-  prop,
+  path,
   defaultValue
 }: {
-  controls: string;
-  prop: string;
+  path: string;
   defaultValue?: string | number | boolean | number[];
 }): ComputedRef => {
   const experienceControls = inject<Dictionary>('experienceControls', {});
 
+  const getByPath = function <T>(this: T, key: string): any {
+    return key.split('.').reduce((obj, prop) => (obj as any)[prop], this);
+  };
   return computed(() => {
-    return experienceControls.value?.controls?.[controls]?.[prop] ?? defaultValue;
+    return getByPath.call(experienceControls.value?.controls, path) ?? defaultValue;
   });
 };

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -1,5 +1,5 @@
 import { computed, ComputedRef } from 'vue';
-import { ExtractPath, getSafePropertyChain } from '@empathyco/x-utils';
+import { getSafePropertyChain } from '@empathyco/x-utils';
 import { ExperienceControlsState } from '@empathyco/x-components/experience-controls';
 import { useStore } from './use-store.composable';
 
@@ -13,19 +13,14 @@ import { useStore } from './use-store.composable';
 export const useExperienceControls = (): {
   getControlFromPath: <SomeType>(path: string, defaultValue?: SomeType) => ComputedRef<SomeType>;
 } => {
-  const experienceControls = (useStore('experienceControls') as ExperienceControlsState).controls
-    .controls;
+  const experienceControls = (useStore('experienceControls') as ExperienceControlsState).controls;
 
   const getControlFromPath = <SomeType>(
     path: string,
     defaultValue?: SomeType
   ): ComputedRef<SomeType> => {
     return computed(() => {
-      return getSafePropertyChain(
-        experienceControls,
-        path as ExtractPath<typeof experienceControls>,
-        defaultValue
-      ) as SomeType;
+      return getSafePropertyChain(experienceControls, path, defaultValue) as SomeType;
     });
   };
 

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -1,0 +1,35 @@
+import { computed, ComputedRef, inject } from 'vue';
+import { Dictionary } from '@empathyco/x-utils';
+
+type ExperienceControlsHelpers = {
+  maxItems: ComputedRef<number>;
+};
+
+/**
+ * Experience controls values per x-modules.
+ *
+ * @param xmodule - The name of the x-module whose config will be set with xControls.
+ * @param prop - The name of the property that will be configured.
+ * @param defaultValue - A default value to set if xControls value is unavailable.
+ *
+ * @returns The experience controls utils.
+ */
+export const useExperienceControlsHelpers = ({
+  xmodule,
+  prop,
+  defaultValue
+}: {
+  xmodule: string;
+  prop: string;
+  defaultValue?: string | number | boolean;
+}): ExperienceControlsHelpers => {
+  const experienceControls = inject<Dictionary>('experienceControls', {});
+
+  const maxItems = computed(() => {
+    return experienceControls.value?.controls?.[xmodule]?.[prop] ?? (defaultValue as number);
+  });
+
+  return {
+    maxItems
+  };
+};

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -3,33 +3,39 @@ import { Dictionary } from '@empathyco/x-utils';
 
 type ExperienceControlsHelpers = {
   maxItems: ComputedRef<number>;
+  columns: ComputedRef<Array<number>>;
 };
 
 /**
  * Experience controls values per x-modules.
  *
- * @param xmodule - The name of the x-module whose config will be set with xControls.
+ * @param controls - The name of the xControls controls object that will be used.
  * @param prop - The name of the property that will be configured.
  * @param defaultValue - A default value to set if xControls value is unavailable.
  *
  * @returns The experience controls utils.
  */
 export const useExperienceControlsHelpers = ({
-  xmodule,
+  controls,
   prop,
   defaultValue
 }: {
-  xmodule: string;
+  controls: string;
   prop: string;
-  defaultValue?: string | number | boolean;
+  defaultValue?: string | number | boolean | number[];
 }): ExperienceControlsHelpers => {
   const experienceControls = inject<Dictionary>('experienceControls', {});
 
   const maxItems = computed(() => {
-    return experienceControls.value?.controls?.[xmodule]?.[prop] ?? (defaultValue as number);
+    return experienceControls.value?.controls?.[controls]?.[prop] ?? (defaultValue as number);
+  });
+
+  const columns = computed(() => {
+    return experienceControls.value?.controls?.[controls]?.[prop] ?? (defaultValue as number[]);
   });
 
   return {
-    maxItems
+    maxItems,
+    columns
   };
 };

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -11,17 +11,28 @@ import { useStore } from './use-store.composable';
  *
  * @returns The experience controls property value.
  */
-export const useXControls = ({
-  path,
-  defaultValue
-}: {
-  path: never;
-  defaultValue?: string | number | boolean | number[];
-}): ComputedRef => {
-  const experienceControls = (useStore('experienceControls') as unknown as ExperienceControlsState)
-    .controls.controls;
+// Rename
+export const useExperienceControls = (): {
+  getControlFromPath: <SomeType>(path: string, defaultValue?: SomeType) => ComputedRef<SomeType>;
+} => {
+  const experienceControls = (useStore('experienceControls') as ExperienceControlsState).controls
+    .controls;
 
-  return computed(() => {
-    return getSafePropertyChain(experienceControls, path, defaultValue);
-  });
+// extracted the current logic to a function. The function can be typed so the return type is known and also it infers the return type from the default value
+  const getControlFromPath = <SomeType>(
+    path: string,
+    defaultValue?: SomeType
+  ): ComputedRef<SomeType> => {
+    return computed(() => {
+      return getSafePropertyChain(
+        experienceControls,
+        path as ExtractPath<typeof experienceControls>,
+        defaultValue
+      ) as SomeType;
+    });
+  };
+
+  return {
+    getControlFromPath
+  };
 };

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -11,7 +11,7 @@ import { useStore } from './use-store.composable';
  *
  * @returns The experience controls property value.
  */
-export const useXControlsHelpers = ({
+export const useXControls = ({
   path,
   defaultValue
 }: {

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -1,17 +1,12 @@
 import { computed, ComputedRef, inject } from 'vue';
 import { Dictionary } from '@empathyco/x-utils';
 
-type ExperienceControlsHelpers = {
-  maxItems: ComputedRef<number>;
-  columns: ComputedRef<Array<number>>;
-};
-
 /**
  * Experience controls values per x-modules.
  *
- * @param controls - The name of the xControls controls object that will be used.
- * @param prop - The name of the property that will be configured.
- * @param defaultValue - A default value to set if xControls value is unavailable.
+ * @param controls - The name of the xControls object that will be used.
+ * @param prop - The name of the property value that will be set.
+ * @param defaultValue - A default value to set if xControls one is unavailable.
  *
  * @returns The experience controls utils.
  */
@@ -23,19 +18,10 @@ export const useXControlsHelpers = ({
   controls: string;
   prop: string;
   defaultValue?: string | number | boolean | number[];
-}): ExperienceControlsHelpers => {
+}): ComputedRef => {
   const experienceControls = inject<Dictionary>('experienceControls', {});
 
-  const maxItems = computed(() => {
-    return experienceControls.value?.controls?.[controls]?.[prop] ?? (defaultValue as number);
+  return computed(() => {
+    return experienceControls.value?.controls?.[controls]?.[prop] ?? defaultValue;
   });
-
-  const columns = computed(() => {
-    return experienceControls.value?.controls?.[controls]?.[prop] ?? (defaultValue as number[]);
-  });
-
-  return {
-    maxItems,
-    columns
-  };
 };

--- a/src/composables/use-experience-controls.composable.ts
+++ b/src/composables/use-experience-controls.composable.ts
@@ -1,24 +1,21 @@
 import { computed, ComputedRef } from 'vue';
-import { getSafePropertyChain } from '@empathyco/x-utils';
+import { ExtractPath, getSafePropertyChain } from '@empathyco/x-utils';
 import { ExperienceControlsState } from '@empathyco/x-components/experience-controls';
 import { useStore } from './use-store.composable';
 
 /**
  * Given a controls' object property chain, gets the experience controls values from the response.
+ * A defaultValue can be set as a safeguard in case the controls response was empty.
  *
- * @param path - The chain of properties in an xControls object.
- * @param defaultValue - A default value to set if xControls one is unavailable.
- *
- * @returns The experience controls property value.
+ * @returns An object containing the function to search for a configuration
+ * and set the experience controls property value.
  */
-// Rename
 export const useExperienceControls = (): {
   getControlFromPath: <SomeType>(path: string, defaultValue?: SomeType) => ComputedRef<SomeType>;
 } => {
   const experienceControls = (useStore('experienceControls') as ExperienceControlsState).controls
     .controls;
 
-// extracted the current logic to a function. The function can be typed so the return type is known and also it infers the return type from the default value
   const getControlFromPath = <SomeType>(
     path: string,
     defaultValue?: SomeType

--- a/src/composables/use-store.composable.ts
+++ b/src/composables/use-store.composable.ts
@@ -1,0 +1,15 @@
+import { getCurrentInstance } from 'vue';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { RootXStoreState, StatusState, XModuleName, XModulesTree } from '@empathyco/x-components';
+
+/**
+ * Provides access to the global store object or to the specific store module if it's provided.
+ *
+ * @param storeModule - The {@link XModuleName}.
+ * @returns A state object.
+ */
+export function useStore(storeModule?: keyof XModulesTree): RootXStoreState | StatusState {
+  return storeModule
+    ? getCurrentInstance()!.proxy.$root.$store.state.x[storeModule]
+    : getCurrentInstance()!.proxy.$root.$store.state.x;
+}

--- a/src/composables/use-store.composable.ts
+++ b/src/composables/use-store.composable.ts
@@ -1,3 +1,4 @@
+// TODO: Change when useStore composable is added in x-components
 import { getCurrentInstance } from 'vue';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { RootXStoreState, StatusState, XModuleName, XModulesTree } from '@empathyco/x-components';


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Use XControls to config:
- The `maxNextQueriesPerGroup` to be shown
- Column options to display for desktop

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
**Test with `dress` and `useXControls` composable inside `custom-query-preview.vue` component to quickly see the changes** ([you can check this commit to do so](https://github.com/empathyco/x-archetype/pull/360/commits/9e8cd12e4f9ae654ebd46401bfdaac28acf2d512))

Tests performed according to [testing guidelines](https://github.com/empathyco/x/blob/main/.github/contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
