### PR TITLE
fix: lazy loading chunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "rollup": "~2.79.0",
         "rollup-plugin-copy": "~3.5.0",
         "rollup-plugin-delete": "~2.0.0",
-        "rollup-plugin-generate-html-template": "1.7.0",
+        "rollup-plugin-generate-html-template": "1.6.1",
         "rollup-plugin-sourcemaps": "~0.6.3",
         "rollup-plugin-styles": "~4.0.0",
         "rollup-plugin-terser": "~7.0.2",
@@ -22921,9 +22921,9 @@
       }
     },
     "node_modules/rollup-plugin-generate-html-template": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-generate-html-template/-/rollup-plugin-generate-html-template-1.7.0.tgz",
-      "integrity": "sha512-05i19ngy9YQwFLteyGa4lyhjlyOGXgoz/xQu+wxty3PIdFtbRMs35SG4SjZfgPsBPyDW4sr4uZ1PUw+eeDx9aw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-generate-html-template/-/rollup-plugin-generate-html-template-1.6.1.tgz",
+      "integrity": "sha512-y3fByHIEokUcu0k47//8OCKl7j4+pEA8/bkyEKYloo2yNjBYlxjCA/9Lx73tFP2NwgYdIXaSdN/gCn5oIdrLmA==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^7.0.1"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rollup": "~2.79.0",
     "rollup-plugin-copy": "~3.5.0",
     "rollup-plugin-delete": "~2.0.0",
-    "rollup-plugin-generate-html-template": "1.7.0",
+    "rollup-plugin-generate-html-template": "1.6.1",
     "rollup-plugin-sourcemaps": "~0.6.3",
     "rollup-plugin-styles": "~4.0.0",
     "rollup-plugin-terser": "~7.0.2",


### PR DESCRIPTION
Recently we discovered an issue with the dynamic chunks being loaded all at once instead of lazy. This is related to an issue on the latest version for [rollup-plugin-generate-html-template ](https://github.com/bengsfort/rollup-plugin-generate-html-template/issues/34).

This PR makes the version stick to previous one until the issue is solved.