### PR TITLE
Change empathize layout for mobile devices

### DIFF
--- a/src/components/mobile/mobile.vue
+++ b/src/components/mobile/mobile.vue
@@ -13,7 +13,9 @@
 
     <div class="x-layout-expand" :class="{ 'x-layout-stack': $x.query.search }">
       <LocationProvider location="predictive_layer" class="x-z-10">
-        <PredictiveLayer :class="{ 'x-mb-56': !$x.query.search }" />
+        <PredictiveLayer
+          :class="{ 'x-mb-40 x-border-b x-border-neutral-10 x-pb-16': !$x.query.search }"
+        />
       </LocationProvider>
 
       <!-- Results -->

--- a/src/components/mobile/mobile.vue
+++ b/src/components/mobile/mobile.vue
@@ -11,9 +11,9 @@
       </div>
     </div>
 
-    <div class="x-layout-stack x-layout-expand">
+    <div class="x-layout-expand" :class="{ 'x-layout-stack': $x.query.search }">
       <LocationProvider location="predictive_layer" class="x-z-10">
-        <PredictiveLayer />
+        <PredictiveLayer :class="{ 'x-mb-56': !$x.query.search }" />
       </LocationProvider>
 
       <!-- Results -->

--- a/src/components/predictive-layer/predictive-popular-searches.vue
+++ b/src/components/predictive-layer/predictive-popular-searches.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="x-flex x-flex-col x-gap-4">
+  <div class="x-mt-8 x-flex x-flex-col x-gap-4 desktop:x-mt-0">
     <h1 class="x-title4 x-title4-sm x-uppercase">
       {{ $t('popularSearches.title') }}
     </h1>
@@ -10,7 +10,7 @@
     >
       <template #suggestion="{ suggestion }">
         <PopularSearch
-          class="x-suggestion-lg x-suggestion desktop:x-suggestion-md"
+          class="x-suggestion x-suggestion-lg desktop:x-suggestion-md"
           :suggestion="suggestion"
         >
           <TrendingIcon class="x-icon-lg desktop:x-icon-md" />


### PR DESCRIPTION
[EMP-3460](https://searchbroker.atlassian.net/browse/EMP-3460)

Currently in the archetype for mobile devices, the query previews are shown in the pre-search state. However, once you focus on the search box there is no way to go back and see the query previews since the empathize is always taking the full height of the device.

Changes (only mobile): 
- Removed the `x-layout-stack` class when there is no query, so query previews are still shown below the predictive layer & user can scroll to its content.
- Add spacing below the predictive layer, so the spacing between it & query previews is consistent (visually we have the same space between predictive as the one between each queries preview carousel). 
- Add the `x-mt-8` in popular searches: this was sometimes a recurring change in setups, as the distance between history queries & popular searches block was fewer than between popular searches & top clicked carousel one.

[EMP-3460]: https://searchbroker.atlassian.net/browse/EMP-3460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ