### PR TITLE
feat: add class to root container for x

### DIFF
--- a/src/x-components/plugin.options.ts
+++ b/src/x-components/plugin.options.ts
@@ -60,6 +60,7 @@ function getDomElement({ isolate }: SnippetConfig): Element {
 
   if (isolate || process.env.NODE_ENV === 'production') {
     const container = document.createElement('div');
+    container.classList.add('x-root-container');
     const shadowRoot = container.attachShadow({ mode: 'open' });
     shadowRoot.appendChild(domElement);
     document.body.appendChild(container);


### PR DESCRIPTION
Add a css class to the root div that contains the x layer. The goal is to have a simple selector for the whole layer.