### PR TITLE
feat: track query when a result of a QP is clicked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@empathyco/x-adapter": "^8.0.3-alpha.1",
         "@empathyco/x-adapter-platform": "^1.1.0-alpha.1",
         "@empathyco/x-archetype-utils": "^1.1.0-alpha.2",
-        "@empathyco/x-components": "^4.1.0-alpha.14",
+        "@empathyco/x-components": "^4.1.0-alpha.19",
         "@empathyco/x-deep-merge": "^2.0.3-alpha.1",
         "@empathyco/x-types": "^10.1.0-alpha.2",
         "@empathyco/x-utils": "^1.0.3-alpha.1",
@@ -2156,9 +2156,9 @@
       }
     },
     "node_modules/@empathyco/x-components": {
-      "version": "4.1.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-4.1.0-alpha.14.tgz",
-      "integrity": "sha512-Dsl9495F4SfrMm9JJOa2DZyUeVIuuoM2q2uDYjRb2zZ+lrELDjiz5idf8Na98DZIdic2MABSyJeL/cA6A/nSSw==",
+      "version": "4.1.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-4.1.0-alpha.19.tgz",
+      "integrity": "sha512-DPGzee2/fYARQu2WflGoAMOHRVQQpALbjAq5Hdk4rJnrIMwhAneVSTnvd+8V6hCa3MDeK9VDiK1MoZZlA9MMEw==",
       "dependencies": {
         "@empathyco/x-adapter": "^8.0.3-alpha.1",
         "@empathyco/x-adapter-platform": "^1.1.0-alpha.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@empathyco/x-adapter": "^8.0.3-alpha.1",
         "@empathyco/x-adapter-platform": "^1.1.0-alpha.1",
         "@empathyco/x-archetype-utils": "^1.1.0-alpha.2",
-        "@empathyco/x-components": "^4.1.0-alpha.19",
+        "@empathyco/x-components": "^4.1.0-alpha.20",
         "@empathyco/x-deep-merge": "^2.0.3-alpha.1",
         "@empathyco/x-types": "^10.1.0-alpha.2",
         "@empathyco/x-utils": "^1.0.3-alpha.1",
@@ -2156,9 +2156,9 @@
       }
     },
     "node_modules/@empathyco/x-components": {
-      "version": "4.1.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-4.1.0-alpha.19.tgz",
-      "integrity": "sha512-DPGzee2/fYARQu2WflGoAMOHRVQQpALbjAq5Hdk4rJnrIMwhAneVSTnvd+8V6hCa3MDeK9VDiK1MoZZlA9MMEw==",
+      "version": "4.1.0-alpha.21",
+      "resolved": "https://registry.npmjs.org/@empathyco/x-components/-/x-components-4.1.0-alpha.21.tgz",
+      "integrity": "sha512-H1xxxBlUv7NjFOQF7lYFI7m2sJsRIfrRgQB+6cuYeXCrGLutkxkUX9LcLSmz1XOjfoZhyEzVQyN3Azs23GvxKg==",
       "dependencies": {
         "@empathyco/x-adapter": "^8.0.3-alpha.1",
         "@empathyco/x-adapter-platform": "^1.1.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@empathyco/x-adapter": "^8.0.3-alpha.1",
     "@empathyco/x-adapter-platform": "^1.1.0-alpha.1",
     "@empathyco/x-archetype-utils": "^1.1.0-alpha.2",
-    "@empathyco/x-components": "^4.1.0-alpha.19",
+    "@empathyco/x-components": "^4.1.0-alpha.20",
     "@empathyco/x-deep-merge": "^2.0.3-alpha.1",
     "@empathyco/x-types": "^10.1.0-alpha.2",
     "@empathyco/x-utils": "^1.0.3-alpha.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@empathyco/x-adapter": "^8.0.3-alpha.1",
     "@empathyco/x-adapter-platform": "^1.1.0-alpha.1",
     "@empathyco/x-archetype-utils": "^1.1.0-alpha.2",
-    "@empathyco/x-components": "^4.1.0-alpha.14",
+    "@empathyco/x-components": "^4.1.0-alpha.19",
     "@empathyco/x-deep-merge": "^2.0.3-alpha.1",
     "@empathyco/x-types": "^10.1.0-alpha.2",
     "@empathyco/x-utils": "^1.0.3-alpha.1",

--- a/src/components/pre-search/custom-query-preview.vue
+++ b/src/components/pre-search/custom-query-preview.vue
@@ -5,7 +5,7 @@
     :queriesPreviewInfo="queriesPreviewInfo"
     :persistInCache="true"
     :queryFeature="queryFeature"
-    #default="{ queryPreviewInfo, totalResults, results }"
+    #default="{ queryPreviewInfo, totalResults, results, queryTagging }"
   >
     <div class="x-mb-40 x-flex x-flex-col x-gap-2 desktop:x-mb-64 desktop:x-gap-16">
       <h1 class="x-title1 max-desktop:x-title1-sm max-desktop:x-px-16">
@@ -22,7 +22,7 @@
             <ArrowRightIcon class="x-icon-lg" />
           </QueryPreviewButton>
         </template>
-        <DisplayClickProvider resultFeature="brand_recommendations">
+        <DisplayClickProvider resultFeature="brand_recommendations" :queryTagging="queryTagging">
           <div class="x-transform-style-3d x-flex x-gap-16 x-pt-16 max-desktop:x-px-16">
             <Result
               v-for="result in results"

--- a/src/components/search/display-click-provider.vue
+++ b/src/components/search/display-click-provider.vue
@@ -7,6 +7,7 @@
 <script lang="ts">
   import { DisplayWireMetadata, NoElement, ResultFeature, use$x } from '@empathyco/x-components';
   import { computed, defineComponent, PropType, provide } from 'vue';
+  import { TaggingRequest } from '@empathyco/x-types';
 
   export default defineComponent({
     components: {
@@ -20,6 +21,11 @@
       ignoreResultClickEvent: {
         type: Boolean,
         default: false
+      },
+      queryTagging: {
+        type: Object as PropType<TaggingRequest>,
+        required: false,
+        default: undefined
       }
     },
     setup(props) {
@@ -27,7 +33,8 @@
 
       const displayClickMetadata = computed<Partial<DisplayWireMetadata>>(() => ({
         displayOriginalQuery: $x.query.search,
-        feature: props.resultFeature
+        feature: props.resultFeature,
+        queryTagging: props.queryTagging
       }));
 
       provide('resultClickExtraEvents', ['UserClickedADisplayResult']);


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Update the Archetype project with the last version of `x-components` and with the approach of track query when a result of a QueryPreview is clicked.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-3538](https://searchbroker.atlassian.net/browse/EMP-3538)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Open the devTools and go to the Network option. Click on a result of a QueryPreview and check if click, displayClick and query are sent.

## Checklist:

- [ ] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[EMP-3538]: https://searchbroker.atlassian.net/browse/EMP-3538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ