### PR TITLE
fix: remove redundant use of computed in query

### DIFF
--- a/src/components/search/results/custom-next-query-preview.vue
+++ b/src/components/search/results/custom-next-query-preview.vue
@@ -64,12 +64,11 @@
     setup() {
       const { isTabletOrLess } = useDevice();
       const maxItemsToRender = computed(() => (isTabletOrLess.value ? undefined : 5));
-      const queryGetter = useGetter('nextQueries', ['query'])['query'];
-      const query = computed(() => queryGetter.value);
+      const queryGetter = useGetter('nextQueries', ['query']);
 
       return {
         maxItemsToRender,
-        query
+        query: queryGetter.query
       };
     }
   });


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
We were wrapping the value of a computed property (queryGetter) inside of another computed property (query).

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
To test it, you can use env=live and:
1)query=shoulder bag
2)query=shoulder + relatedTag=bag
3)query=shoulder + relatedTag=bag + relatedTag=velvet