### PR TITLE
Fix autoFocus in the searchBox in mobile version to handle no QueryPreviews scenario

### DIFF
--- a/src/components/custom-main-modal.vue
+++ b/src/components/custom-main-modal.vue
@@ -30,9 +30,7 @@
        * Sets focusOnOpen to false if there are no query previews
        * to avoid having to click the input manually to be able to write.
        */
-      const focusOnOpen = !(
-        !!snippetConfig.queriesPreview && snippetConfig.queriesPreview.length > 0
-      );
+      const focusOnOpen = !!snippetConfig.queriesPreview && snippetConfig.queriesPreview.length > 0;
 
       return {
         animation: animateClipPath(),

--- a/src/components/custom-main-modal.vue
+++ b/src/components/custom-main-modal.vue
@@ -1,13 +1,17 @@
 <template>
-  <MainModal :animation="animation" :class="`x-${deviceName}`" :focusOnOpen="isTabletOrLess">
+  <MainModal
+    :animation="animation"
+    :class="`x-${deviceName}`"
+    :focusOnOpen="isTabletOrLess && focusOnOpen"
+  >
     <Mobile v-if="isTabletOrLess" />
     <Desktop v-else />
   </MainModal>
 </template>
 
 <script lang="ts">
-  import { defineComponent } from 'vue';
-  import { animateClipPath, MainModal } from '@empathyco/x-components';
+  import { defineComponent, inject } from 'vue';
+  import { animateClipPath, MainModal, SnippetConfig } from '@empathyco/x-components';
   import { useDevice } from '../composables/use-device.composable';
   import Mobile from './mobile/mobile.vue';
   import Desktop from './desktop/desktop.vue';
@@ -20,10 +24,21 @@
     },
     setup() {
       const { isTabletOrLess, deviceName } = useDevice();
+      const snippetConfig = <SnippetConfig>inject('snippetConfig');
+
+      /**
+       * Sets focusOnOpen to false if there are no query previews
+       * to avoid having to click the input manually to be able to write.
+       */
+      const focusOnOpen = !(
+        !!snippetConfig.queriesPreview && snippetConfig.queriesPreview.length > 0
+      );
+
       return {
         animation: animateClipPath(),
         deviceName,
-        isTabletOrLess
+        isTabletOrLess,
+        focusOnOpen
       };
     }
   });


### PR DESCRIPTION
**TO TEST**: search-box component needs autofocus set to `true` & QueriesPreview removed from snippetConfig.

Sets `focusOnOpen` to false if there are no query previews to avoid having to click the input manually to be able to write.
See [EMP-77](https://searchbroker.atlassian.net/browse/EMP-77) as reference.

<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: EMP-3650

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](https://github.com/empathyco/x/blob/main/.github/contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[EMP-77]: https://searchbroker.atlassian.net/browse/EMP-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ