### PR TITLE
fix: using .value in second part of columns conditional so columns.va…

### DIFF
--- a/src/components/column-picker.vue
+++ b/src/components/column-picker.vue
@@ -38,11 +38,11 @@
       const { getControlFromPath } = useExperienceControls();
 
       const columns = computed(() =>
-        isMobile.value ? [2, 1] : getControlFromPath('layout.columnSelector', [4, 2])
+        isMobile.value ? [2, 1] : getControlFromPath('layout.columnSelector', [4, 2]).value
       );
 
       return {
-        values: columns.value,
+        values: columns,
         icons: { 1: 'Grid1ColIcon', 2: 'Grid2ColIcon', 4: 'Grid4ColIcon' }
       };
     }


### PR DESCRIPTION
…lue is always array<number>

<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Columns mapping expects a value coming from a computed property. To fix it in [last PR](https://github.com/empathyco/x-archetype/pull/461), we had added a `.value` to the `columns` property, but the reactivity was not working. The real problem was that in columns computed property the second part of the conditional was returning a computed value, so we had a computed within another (columns.value was of type number[] | ComputedRef<number[]>). In the template, it was already accessing the value of the property. Now, by using .value to ensure that columns is always a ComputedRef<number[]>, everything seems to work fine.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-3706](https://searchbroker.atlassian.net/browse/EMP-3706)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Column picker should appear and should be reactive.

## Checklist:

- [ ] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[EMP-3706]: https://searchbroker.atlassian.net/browse/EMP-3706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
