### PR TITLE
feat: use staging endpoints for rts nqs in docker

### DIFF
--- a/src/adapter/docker.adapter.ts
+++ b/src/adapter/docker.adapter.ts
@@ -59,16 +59,16 @@ type DockerEndpoints = Exclude<keyof XComponentsAdapter, 'tagging'>;
  * @returns The url for the given endpoint.
  */
 function resolveEmpathyEndpoint(endpoint: DockerEndpoints, context: Record<string, any>): string {
-  const { empathyAPIHost, instance } = context;
+  const { empathyAPIHost } = context;
   const endpointHost: string = empathyAPIHost ? empathyAPIHost : 'localhost:8080';
-  const endpointInstance: string = instance ? instance : 'imdb';
+  const endpointInstance = 'imdb';
   const empathyEndpoints: Record<DockerEndpoints, string> = {
     search: `http://${endpointHost}/query/${endpointInstance}/search`,
     popularSearches: `http://${endpointHost}/query/${endpointInstance}/empathize`,
     recommendations: `http://${endpointHost}/query/${endpointInstance}/topclicked`,
-    nextQueries: `http://${endpointHost}/nextqueries/${endpointInstance}`,
+    nextQueries: `https://api.staging.empathy.co/nextqueries/${endpointInstance}`,
     querySuggestions: `http://${endpointHost}/query/${endpointInstance}/empathize`,
-    relatedTags: `http://${endpointHost}/relatedtags/${endpointInstance}`,
+    relatedTags: `https://api.staging.empathy.co/relatedtags/${endpointInstance}`,
     identifierResults: `http://${endpointHost}/query/${endpointInstance}/skusearch`,
     semanticQueries: `http://${endpointHost}/semantics-api/search_single/${endpointInstance}`,
     experienceControls: `http://${endpointHost}/config/v1/public/configs`

--- a/src/x-components/plugin.options.ts
+++ b/src/x-components/plugin.options.ts
@@ -18,7 +18,6 @@ export async function getInstallXOptions(): Promise<InstallXOptions> {
   if (process.env.VUE_APP_DEVELOPMENT_DOCKER) {
     const { overrideAdapter } = await import('../adapter/docker.adapter');
     overrideAdapter(adapter);
-    (window.initX as SnippetConfig).lang = 'es';
   }
   return {
     adapter,


### PR DESCRIPTION
For docker environment use always 'imdb' as the instance and point to the staging endpoints for RTs and NQs