### PR TITLE
Using RT and NQ Production Endpoints for SMC

### DIFF
--- a/src/adapter/docker.adapter.ts
+++ b/src/adapter/docker.adapter.ts
@@ -66,9 +66,9 @@ function resolveEmpathyEndpoint(endpoint: DockerEndpoints, context: Record<strin
     search: `http://${endpointHost}/query/${endpointInstance}/search`,
     popularSearches: `http://${endpointHost}/query/${endpointInstance}/empathize`,
     recommendations: `http://${endpointHost}/query/${endpointInstance}/topclicked`,
-    nextQueries: `https://api.staging.empathy.co/nextqueries/${endpointInstance}`,
+    nextQueries: `https://api.empathy.co/nextqueries/${endpointInstance}`,
     querySuggestions: `http://${endpointHost}/query/${endpointInstance}/empathize`,
-    relatedTags: `https://api.staging.empathy.co/relatedtags/${endpointInstance}`,
+    relatedTags: `https://api.empathy.co/relatedtags/${endpointInstance}`,
     identifierResults: `http://${endpointHost}/query/${endpointInstance}/skusearch`,
     semanticQueries: `http://${endpointHost}/semantics-api/search_single/${endpointInstance}`,
     experienceControls: `http://${endpointHost}/config/v1/public/configs`


### PR DESCRIPTION
Because of resources, we need to use the data bot in production environment to generate the data for SMC, so now we will consume those endpoints

# Pull request template
I have changed the hardcoded URLs for related tags and next queries to use production endpoints (already working) instead of staging endpoints.

## Motivation and context
The motivation was that we needed the bot to be able to consume more resources so he could ingest our feed. Instead of changing it for all staging clients, we will use the instance on production environment as that one already has the needed resources.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

I have already tested the endpoints. They contain information in the same format as staging and the URLs I wrote are correct
