### PR TITLE
fix: Send spellchecked query to Backroom

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,7 +22,7 @@
   import { QueryPreviewInfo } from '@empathyco/x-components/queries-preview';
   import { UrlHandler } from '@empathyco/x-components/url';
   import { SnippetConfigExtraParams } from '@empathyco/x-components/extra-params';
-  import { InternalSearchRequest } from '@empathyco/x-components/search';
+  import { InternalSearchRequest, InternalSearchResponse } from '@empathyco/x-components/search';
   import { Component, Inject, Provide, Vue, Watch } from 'vue-property-decorator';
   import { useDevice } from './composables/use-device.composable';
   import currencies from './i18n/currencies';
@@ -60,11 +60,14 @@
     }
 
     @XOn(['SearchRequestChanged'])
-    setWysiwygContext(payload: InternalSearchRequest | null): void {
-      const { wysiwyg } = window;
-      if (wysiwyg) {
-        const query = this.$x.spellcheckedQuery! || payload?.query;
-        wysiwyg.setContext({ query });
+    onSearchRequestChanged(payload: InternalSearchRequest | null): void {
+      window.wysiwyg?.setContext({ query: payload?.query, spellcheckedQuery: undefined });
+    }
+
+    @XOn(['SearchResponseChanged'])
+    onSearchResponseChanged(payload: InternalSearchResponse): void {
+      if (payload.spellcheck) {
+        window.wysiwyg?.setContext({ spellcheckedQuery: payload.spellcheck });
       }
     }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,7 +61,11 @@
 
     @XOn(['SearchRequestChanged'])
     setWysiwygContext(payload: InternalSearchRequest | null): void {
-      window.wysiwyg?.setContext({ query: payload?.query });
+      const { wysiwyg } = window;
+      if (wysiwyg) {
+        const query = this.$x.spellcheckedQuery! || payload?.query;
+        wysiwyg.setContext({ query });
+      }
     }
 
     @XOn(['ParamsLoadedFromUrl'])

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,12 @@ declare global {
       requestAuth: () => Promise<void>;
       open: () => Promise<void>;
       close: () => Promise<void>;
-      setContext: (newContext: { query: string | undefined }) => void;
+      setContext: (
+        newContext: Partial<{
+          query: string | undefined;
+          spellcheckedQuery: string | undefined;
+        }>
+      ) => void;
     };
   }
 }


### PR DESCRIPTION
## Motivation and context
When available the spellchecked query must be sent to Backroom instead of the written one so tooling can be properly applied to the displayed results.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
- [x] `Main`

## Checklist:
- [x] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [xx] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
