### PR TITLE
fix: Fix backroom back from login context issue

### DIFF
--- a/public/snippet-script.js
+++ b/public/snippet-script.js
@@ -119,7 +119,7 @@ window.addEventListener('load', () => {
     instance,
     lang,
     audience: 'enterprise',
-    playboardUrl: 'https://playboard-platform.staging.empathy.co/empathy',
+    playboardUrl: `https://playboard-platform.staging.empathy.co/${instance}`,
     appContainerSelector: '.x-root-container',
     searchLayerSelector: '.x'
   });

--- a/public/snippet-script.js
+++ b/public/snippet-script.js
@@ -116,9 +116,10 @@ window.addEventListener('load', () => {
     analytics: {
       baseUrl: 'https://api.staging.empathy.co/statistics/v2'
     },
-    lang,
     instance,
+    lang,
     audience: 'enterprise',
+    playboardUrl: 'https://playboard-platform.staging.empathy.co/empathy',
     appContainerSelector: '.x-root-container',
     searchLayerSelector: '.x'
   });

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,7 +72,6 @@
     }
 
     @XOn(['ParamsLoadedFromUrl'])
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async requestAuthWysiwyg(payload: UrlParams): Promise<void> {
       try {
         if (window.wysiwyg) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -78,6 +78,7 @@
         if (window.wysiwyg) {
           await window.wysiwyg?.requestAuth();
           window.InterfaceX?.search();
+          window.wysiwyg?.setContext({ query: payload.query });
         }
       } catch (_) {
         // No error handling


### PR DESCRIPTION
## Motivation and context
We have a bug in Backroom in which if after performing a query the user logs in, when returning to the Search layer Backroom context is not updated.

This is because the Backroom context was only updated with the `SearchRequestChanged`event but that event is not fired in the first search if loaded from the URL; adding a single line on the `ParamsLoadedFromUrl` fixes the issue.

- [x] Open issue: https://searchbroker.atlassian.net/browse/PBU-31

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
- [x] `Main`

## Checklist:
- [x] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
