### PR TITLE
feat: show no result fallback in this order 1.semantics 2.partials 3.…

### DIFF
--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -6,22 +6,22 @@
       <LocationProvider location="results">
         <Results />
       </LocationProvider>
-
-      <LocationProvider location="results">
+      <LocationProvider :location="semanticsLocation">
+        <CustomSemanticQueries />
+      </LocationProvider>
+      <LocationProvider v-if="!$x.semanticQueries.length" location="results">
         <PartialResults />
       </LocationProvider>
-      <LocationProvider v-if="$x.noResults && !$x.partialResults.length" location="no_results">
+      <LocationProvider v-if="showRecommendations" location="no_results">
         <CustomRecommendations />
       </LocationProvider>
-
-      <CustomSemanticQueries />
     </template>
   </div>
 </template>
 
 <script lang="ts">
-  import { LocationProvider } from '@empathyco/x-components';
-  import { defineComponent } from 'vue';
+  import { FeatureLocation, LocationProvider, use$x } from '@empathyco/x-components';
+  import { ComputedRef, computed, defineComponent } from 'vue';
   import { useHasSearched } from '../composables/use-has-searched.composable';
   import CustomRecommendations from './results/custom-recommendations.vue';
   import CustomSemanticQueries from './search/custom-semantic-queries.vue';
@@ -37,7 +37,14 @@
     },
     setup() {
       const { hasSearched } = useHasSearched();
-      return { hasSearched };
+      const $x = use$x();
+      const semanticsLocation: ComputedRef<FeatureLocation> = computed(() =>
+        $x.results.length > 0 ? 'low_results' : 'no_results'
+      );
+      const showRecommendations: ComputedRef<boolean> = computed(
+        () => $x.noResults && !$x.partialResults.length && !$x.semanticQueries.length
+      );
+      return { hasSearched, semanticsLocation, showRecommendations };
     }
   });
 </script>


### PR DESCRIPTION
…recommendations

<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
The desired order for no result fallback is:
1. Semantics
2. Partials
3. Recommendations

So we need to implement this logic in the archetype to avoid having to do it in every new client setup.
<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

1. search for a query with semantics
2. in vue devtools remove semanticQueries
3. If there are partials you should see them, if not you will see topclicked.
'camiseta para mi boda mañana' has semantics but no partials
'camiseta para mi cumpleaños' has semantics and partials


Tests performed according to [testing guidelines](https://github.com/empathyco/x/blob/main/.github/contributing/tests.md): 

