### PR TITLE
ci: bump node version to 22

### DIFF
--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
     - name: Installing dependencies
       run: npm ci
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - name: Install deps, lint, build and test project
         uses: ./.github/actions/install
       # Every push to main deploys to staging

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -25,7 +25,7 @@ jobs:
       # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - name: Installing dependencies
         run: npm ci
         shell: bash

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - name: Install deps, lint, build and test project
         uses: ./.github/actions/install
       - name: Deploy PR Preview


### PR DESCRIPTION
This pull request updates the Node.js version used in various GitHub Actions workflows from version 18 to version 22. The most important changes are as follows:

Updates to Node.js version:

* [`.github/actions/install/action.yaml`](diffhunk://#diff-1c50054d5c05df1fa07c9f0853b2f3673d3d993d74a7bdbd2b46f9845acc6f65L9-R9): Updated `node-version` from '18' to '22' in the `steps` section.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L17-R17): Updated `node-version` from '18' to '22' in the `jobs` section.
* [`.github/workflows/deploy-docker.yml`](diffhunk://#diff-04ec4378b9f42e59c8776517c7b3c7eeacdde33056482e31a85d41d7439101a1L28-R28): Updated `node-version` from '18' to '22' in the `jobs` section.
* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L21-R21): Updated `node-version` from '18' to '22' in the `jobs` section.