### PR TITLE
refactor: remove next queries from related prompt tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1229,7 +1229,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/components/related-prompts/custom-related-prompts.vue
+++ b/src/components/related-prompts/custom-related-prompts.vue
@@ -12,11 +12,11 @@
     </i18n-t>
 
     <div class="x-flex x-flex-col">
-      <RelatedPromptsTagList class="x-my-24" />
+      <RelatedPromptsTagList class="x-mt-24" />
       <CustomQueryPreview
         v-if="selectedPrompt !== -1"
         :key="queriesPreviewInfo.length"
-        class="x-rounded-[12px] x-bg-neutral-10 x-px-16"
+        class="x-rounded-b-[12px] x-bg-neutral-10 x-px-16"
         :queries-preview-info="queriesPreviewInfo"
       ></CustomQueryPreview>
     </div>

--- a/src/components/related-prompts/related-prompts-tag-list.vue
+++ b/src/components/related-prompts/related-prompts-tag-list.vue
@@ -14,11 +14,13 @@
         v-for="(suggestion, index) in relatedPrompts"
         :key="index"
         :style="{ animationDelay: `${index * 0.4 + 0.05}s` }"
-        class="x-text-neutral-80 x-flex x-h-[112px] x-flex-col x-rounded-[12px] x-bg-neutral-10 x-text-md x-font-[400] x-transition-all x-duration-500 x-staggered-initial"
+        class="x-text-neutral-80 x-flex x-flex-col x-rounded-[12px] x-bg-neutral-10 x-text-md x-font-[400] x-transition-all x-duration-500 x-staggered-initial"
         :class="[
           { 'x-staggered-animation': isVisible },
           { 'x-hidden': shouldHideButton(index) },
-          isSelected(index) ? 'x-w-full' : 'x-w-[204px] desktop:x-w-[303px]',
+          isSelected(index)
+            ? 'x-w-full x-rounded-b-none'
+            : 'x-h-[112px] x-w-[204px] desktop:x-w-[303px]',
         ]"
         data-test="related-prompt-item"
       >
@@ -40,38 +42,11 @@
               {{ suggestion.suggestionText }}
             </span>
           </div>
-          <div class="x-mr-8 x-mt-8">
+          <div :class="{ 'x-mr-8 x-mt-8': !isSelected(index) }">
             <CrossTinyIcon v-if="isSelected(index)" class="x-icon-lg" />
             <PlusIcon v-else class="x-icon-neutral-80 x-icon-lg" />
           </div>
         </button>
-
-        <!-- Next queries -->
-        <div
-          v-if="isSelected(index)"
-          class="x-no-scrollbar x-mt-8 x-flex x-w-full x-gap-12 x-overflow-y-hidden x-overflow-x-scroll x-px-16"
-        >
-          <button
-            v-for="(query, queryIndex) in suggestion.nextQueries"
-            :key="query"
-            :style="{ animationDelay: `${queryIndex * 0.3}s` }"
-            class="x-tag-outlined x-flex x-h-[40px] x-items-center x-justify-center x-gap-4 x-rounded-full x-border-1 x-px-12 x-staggered-initial x-staggered-animation"
-            :class="[
-              { 'x-hidden': shouldHideButton(queryIndex) },
-              isQuerySelected(queryIndex) ? 'x-bg-neutral-25' : 'x-bg-neutral-0',
-            ]"
-            @click="toggleQuery(queryIndex)"
-          >
-            <span
-              class="x-whitespace-nowrap x-text-sm"
-              :class="[isQuerySelected(queryIndex) ? ' x-text-neutral-90' : 'x-text-neutral-75']"
-            >
-              {{ query }}
-            </span>
-            <CrossTinyIcon v-if="isQuerySelected(queryIndex)" class="x-text-16 x-h-20" />
-            <PlusIcon v-else class="x-text-16 x-h-20" />
-          </button>
-        </div>
       </div>
     </div>
   </CustomSlidingPanel>
@@ -96,7 +71,6 @@ export default defineComponent({
     const isVisible = ref(false)
 
     const selectedIndex = ref<number>(-1)
-    const selectedQuery = ref<number>(-1)
 
     const observer = new IntersectionObserver(([entry]) => {
       isVisible.value = entry.isIntersecting
@@ -116,51 +90,30 @@ export default defineComponent({
       } else {
         selectedIndex.value = index
       }
-      selectedQuery.value = -1
       x.emit('UserSelectedARelatedPrompt', selectedIndex.value)
-      x.emit('UserSelectedARelatedPromptQuery', selectedQuery.value)
     }
 
     const isSelected = (index: number): boolean => selectedIndex.value === index
 
-    const toggleQuery = (queryIndex: number): void => {
-      if (selectedQuery.value === queryIndex) {
-        selectedQuery.value = -1
-      } else {
-        selectedQuery.value = queryIndex
-      }
-      x.emit('UserSelectedARelatedPromptQuery', selectedQuery.value)
-    }
-
-    const isQuerySelected = (queryIndex: number): boolean => selectedQuery.value === queryIndex
-
     const shouldHideButton = (index: number): boolean =>
       selectedIndex.value !== -1 && selectedIndex.value !== index
 
-    const shouldHideQuery = (queryIndex: number): boolean =>
-      selectedQuery.value !== -1 && selectedQuery.value !== queryIndex
-
     x.on('UserAcceptedAQueryPreview', false).subscribe(() => {
       toggleSuggestion(-1)
-      toggleQuery(-1)
     })
 
     x.on('SearchRequestChanged', false).subscribe(() => {
       toggleSuggestion(-1)
-      toggleQuery(-1)
     })
 
     return {
-      isQuerySelected,
       isSelected,
       isTouchable,
       isVisible,
       relatedPrompts,
       selectedIndex,
       shouldHideButton,
-      shouldHideQuery,
       slidingPanelContent,
-      toggleQuery,
       toggleSuggestion,
     }
   },

--- a/src/components/search/results/results.vue
+++ b/src/components/search/results/results.vue
@@ -31,11 +31,11 @@
               </MainScrollItem>
             </template>
             <template #related-prompts-group>
-              <RelatedPromptsTagList v-if="!isLowResult" class="x-my-24" />
+              <RelatedPromptsTagList v-if="!isLowResult" class="-x-mb-1 x-mt-24 desktop:x-mt-0" />
               <CustomQueryPreview
                 v-if="selectedPrompt !== -1"
                 :key="queriesPreviewInfo.length"
-                class="x-rounded-[12px] x-bg-neutral-10 x-px-8 desktop:x-px-16"
+                class="x-rounded-b-[12px] x-bg-neutral-10 x-px-8 desktop:x-px-16"
                 :queries-preview-info="queriesPreviewInfo"
               ></CustomQueryPreview>
             </template>


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template

<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.-->

Refactor the `RelatedPromptTagList` component to remove the list of next queries inside the prompt tag. With these changes when selecting a prompt, we will show all the previews of the associated next queries.

## Motivation and context

<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: https://searchbroker.atlassian.net/browse/RST-2564

## Type of change

<!-- Indicate the type of change involved in the PR -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?

<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->

- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](https://github.com/empathyco/x/blob/main/.github/contributing/tests.md):

## Checklist:

- [ ] My code follows the **[style guidelines](https://github.com/empathyco/x/blob/main/.github/CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
