### PR TITLE
feat: improve i18n implementation

### DIFF
--- a/src/components/desktop/desktop-toolbar.vue
+++ b/src/components/desktop/desktop-toolbar.vue
@@ -5,7 +5,13 @@
     :class="{ 'x-mb-8': !x.selectedFilters.length }"
     data-test="total-results"
   >
-    <i18n-t class="x-text1 x-text1-lg x-flex-auto" keypath="totalResults.message" tag="span">
+    <i18n-t
+      class="x-text1 x-text1-lg x-flex-auto"
+      keypath="totalResults.message"
+      tag="span"
+      scope="global"
+      :plural="x.totalResults"
+    >
       <template #totalResults>
         {{ x.totalResults }}
       </template>
@@ -24,7 +30,7 @@
       data-test="toggle-facets-button"
     >
       <FiltersIcon class="x-icon-lg" />
-      <span>{{ $t('toggleAside.showAside') }}</span>
+      <span class="x-capitalize">{{ $t('toggleAside.showAside') }}</span>
       <span
         v-if="x.selectedFilters.length"
         :class="{ 'x-badge-circle': x.selectedFilters.length <= 9 }"

--- a/src/components/mobile/mobile-close-aside.vue
+++ b/src/components/mobile/mobile-close-aside.vue
@@ -5,13 +5,13 @@
       class="x-button-lead x-button-outlined x-flex-auto x-rounded-full x-py-12 x-uppercase"
       :always-visible="false"
     >
-      {{ $t('selectedFilters.clear', { selectedFiltersNumber: selectedFilters.length }) }}
+      {{ $t('selectedFilters.clear', selectedFilters.length, { count: selectedFilters.length }) }}
     </ClearFilters>
     <BaseIdModalClose
-      class="x-button-lead x-flex-auto x-rounded-full x-py-12"
+      class="x-button-lead x-flex-auto x-rounded-full x-py-12 x-uppercase"
       modal-id="aside-modal"
     >
-      {{ $t('facetsPanel.viewResults', { totalResults: x.totalResults }) }}
+      {{ $t('facetsPanel.viewResults', x.totalResults, { count: x.totalResults }) }}
     </BaseIdModalClose>
   </div>
 </template>

--- a/src/components/mobile/mobile-open-aside.vue
+++ b/src/components/mobile/mobile-open-aside.vue
@@ -5,7 +5,7 @@
     class="x-button-lead x-rounded-full x-px-16"
   >
     <FiltersIcon class="x-icon-lg" />
-    <span>{{ $t('toggleAside.showAside') }}</span>
+    <span class="x-uppercase">{{ $t('toggleAside.showAside') }}</span>
     <span
       v-if="x.selectedFilters.length > 0"
       :class="{ 'x-badge-circle': x.selectedFilters.length <= 9 }"

--- a/src/components/mobile/mobile-toolbar.vue
+++ b/src/components/mobile/mobile-toolbar.vue
@@ -4,7 +4,13 @@
     class="x-flex x-w-full x-flex-row x-items-center x-justify-between x-gap-16"
   >
     <div class="x-flex x-flex-auto x-items-center x-justify-end">
-      <i18n-t class="x-text1 x-flex-auto" keypath="totalResults.message" tag="span">
+      <i18n-t
+        class="x-text1 x-flex-auto"
+        keypath="totalResults.message"
+        tag="span"
+        scope="global"
+        :plural="x.totalResults"
+      >
         <template #totalResults>
           {{ x.totalResults }}
         </template>

--- a/src/components/my-history/custom-my-history.vue
+++ b/src/components/my-history/custom-my-history.vue
@@ -36,7 +36,7 @@
                   <template v-if="suggestion.totalResults !== undefined">
                     -
                     {{
-                      $t('myHistory.suggestionResults', { totalResults: suggestion.totalResults })
+                      $t('myHistory.suggestionResults', suggestion.totalResults, { count: suggestion.totalResults })
                     }}
                   </template>
                 </p>

--- a/src/components/my-history/my-history-aside.vue
+++ b/src/components/my-history/my-history-aside.vue
@@ -11,7 +11,7 @@
       >
         <CrossIcon class="x-icon-lg x-text-neutral-0" />
       </BaseIdModalClose>
-      <h1 class="desktop:x-title-md x-title2 x-title2-sm x-text-neutral-0">
+      <h1 class="desktop:x-title-md x-title2 x-title2-sm x-capitalize x-text-neutral-0">
         {{ $t('myHistory.title') }}
       </h1>
     </div>
@@ -30,7 +30,7 @@
         class="x-flex x-items-center x-justify-between x-px-16 x-pb-32 x-pt-24 desktop:x-pl-32"
       >
         <div class="x-flex x-flex-col x-gap-4">
-          <span class="x-title3">{{ $t('myHistory.switch.title') }}</span>
+          <span class="x-title3 x-capitalize">{{ $t('myHistory.switch.title') }}</span>
           <span class="x-text1 x-text1-lg x-text-neutral-75">
             {{
               x.isHistoryQueriesEnabled
@@ -40,7 +40,7 @@
           </span>
         </div>
         <HistoryQueriesSwitch
-          :class="{ 'x-selected x-switch--is-selected': x.isHistoryQueriesEnabled }"
+          :class="{ 'x-switch--is-selected x-selected': x.isHistoryQueriesEnabled }"
         />
       </section>
 

--- a/src/components/predictive-layer/full-width-predictive.vue
+++ b/src/components/predictive-layer/full-width-predictive.vue
@@ -106,7 +106,7 @@
                       <BaseIdModalOpen
                         v-if="isDesktopOrGreater && !x.query.searchBox"
                         modal-id="my-history-aside"
-                        class="x-button-neutral x-button-sm x-button-tight x-col-start-[-1] x-self-start"
+                        class="x-button-neutral x-button-sm x-button-tight x-col-start-[-1] x-self-start x-capitalize"
                         data-test="my-history-button"
                       >
                         <SettingsIcon />

--- a/src/components/predictive-layer/predictive-layer.vue
+++ b/src/components/predictive-layer/predictive-layer.vue
@@ -32,7 +32,7 @@
             <BaseIdModalOpen
               v-if="isTabletOrLess && !x.query.searchBox"
               modal-id="my-history-aside"
-              class="x-button-neutral x-button-sm x-button-tight x-self-end x-pr-8"
+              class="x-button-neutral x-button-sm x-button-tight x-self-end x-pr-8 x-capitalize"
             >
               {{ $t('myHistory.openButton') }}
               <SettingsIcon class="x-icon-lg" />

--- a/src/components/results/result.vue
+++ b/src/components/results/result.vue
@@ -24,7 +24,7 @@
         v-if="isDesktopOrGreater && showAddToCart"
         class="x-result__overlay x-invisible x-absolute x-bottom-0 x-flex x-w-full group-hover/result:x-visible"
       >
-        <BaseAddToCart :result="result" class="x-button-lead x-m-16 x-flex-auto x-rounded-full">
+        <BaseAddToCart :result="result" class="x-button-lead x-m-16 x-flex-auto x-rounded-full x-uppercase">
           {{ $t('result.addToCart') }}
         </BaseAddToCart>
       </div>

--- a/src/components/search/desktop-aside.vue
+++ b/src/components/search/desktop-aside.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="x-flex x-min-h-0 x-flex-auto x-flex-col x-bg-neutral-0">
     <div class="x-flex x-items-center x-border-b x-border-neutral-90 x-p-24 x-pl-40 x-pr-32">
-      <span class="x-title2 x-mr-auto">
+      <span class="x-title2 x-mr-auto x-uppercase">
         {{ $t('facetsPanel.title') }}
       </span>
       <BaseIdModalClose class="x-button-lead x-button-circle x-button-ghost" modal-id="right-aside">
@@ -18,13 +18,13 @@
         class="x-button-lead x-button-outlined x-flex-auto x-rounded-full x-p-24 x-py-12 x-uppercase"
         :always-visible="false"
       >
-        {{ $t('selectedFilters.clear', { selectedFiltersNumber: selectedFilters.length }) }}
+        {{ $t('selectedFilters.clear', selectedFilters.length, { count: selectedFilters.length }) }}
       </ClearFilters>
       <BaseIdModalClose
-        class="x-button-lead x-flex-auto x-rounded-full x-p-24 x-py-12"
+        class="x-button-lead x-flex-auto x-rounded-full x-p-24 x-py-12 x-uppercase"
         modal-id="right-aside"
       >
-        {{ $t('facetsPanel.viewResults', { totalResults: x.totalResults }) }}
+        {{ $t('facetsPanel.viewResults', x.totalResults, { count: x.totalResults }) }}
       </BaseIdModalClose>
     </div>
   </div>

--- a/src/components/search/facets/selected-filters.vue
+++ b/src/components/search/facets/selected-filters.vue
@@ -46,10 +46,10 @@
       v-if="isDesktopOrGreater"
       v-slot="{ selectedFilters }"
       data-test="clear-filters-toolbar"
-      class="x-button-lead x-button-sm x-button-outlined x-flex-none x-rounded-full"
+      class="x-button-lead x-button-sm x-button-outlined x-flex-none x-rounded-full x-uppercase"
       :always-visible="false"
     >
-      {{ $t('selectedFilters.clear', { selectedFiltersNumber: selectedFilters.length }) }}
+      {{ $t('selectedFilters.clear', selectedFilters.length, { count: selectedFilters.length }) }}
     </ClearFilters>
   </div>
 </template>
@@ -88,7 +88,7 @@ export default defineComponent({
     return {
       isTabletOrLess,
       isDesktopOrGreater,
-      isTouchable,
+      isTouchable
     }
   },
 })

--- a/src/components/search/fallback-disclaimer-message.vue
+++ b/src/components/search/fallback-disclaimer-message.vue
@@ -1,6 +1,11 @@
 <template>
   <FallbackDisclaimer v-if="x.fromNoResultsWithFilters" class="x-fallback-message x-message">
-    <i18n-t class="x-text1 desktop:x-text1-lg" keypath="fallbackDisclaimer.message" tag="p">
+    <i18n-t
+      class="x-text1 desktop:x-text1-lg"
+      keypath="fallbackDisclaimer.message"
+      tag="p"
+      scope="global"
+    >
       <template #query>
         <span class="x-w-auto x-font-bold">"{{ x.query.search }}"</span>
       </template>

--- a/src/components/search/results/custom-next-query-preview.vue
+++ b/src/components/search/results/custom-next-query-preview.vue
@@ -9,6 +9,7 @@
       class="x-text1 x-text1-lg max-desktop:x-px-16"
       tag="span"
       keypath="nextQueryPreview.message"
+      scope="global"
     >
       <template #query>
         <span class="x-title3">

--- a/src/components/search/spellcheck-message.vue
+++ b/src/components/search/spellcheck-message.vue
@@ -1,7 +1,12 @@
 <template>
   <Spellcheck v-if="x.totalResults > 0" v-slot="{ query }" class="x-message desktop:x-flex-col">
     <p>
-      <i18n-t class="x-text1 desktop:x-text1-lg" keypath="spellcheck.message">
+      <i18n-t
+        class="x-text1 desktop:x-text1-lg"
+        keypath="spellcheck.message"
+        scope="global"
+        tag="p"
+      >
         <template #query>
           <span class="x-w-auto x-font-bold">"{{ query }}".</span>
           <div v-if="isTabletOrLess" class="x-basis-full"></div>

--- a/src/i18n/messages/de.messages.json
+++ b/src/i18n/messages/de.messages.json
@@ -5,7 +5,7 @@
       "placeholder": "Wonach suchen Sie?"
     },
     "popularSearches": {
-      "title": "Beliebte Suchanfragen"
+      "title": "Beliebte suchanfragen"
     },
     "historyQueries": {
       "clear": "Alle löschen",
@@ -13,7 +13,7 @@
       "title": "Verlaufsanfragen"
     },
     "myHistory": {
-      "title": "Mein Verlauf",
+      "title": "Mein verlauf",
       "subtitle": "Dies ist die vollständige Liste der Verlaufsanfragen",
       "message": {
         "header": "Diese Daten werden lokal gespeichert. Nur auf Ihrem Gerät und verlassen es nie.",
@@ -21,8 +21,8 @@
         "footer": "Ihre Privatsphäre unter Ihrer Kontrolle."
       },
       "noHistory": "Keine Verlaufaktivität vorhanden",
-      "openButton": "Mein Verlauf",
-      "suggestionResults": "({totalResults} Ergebnisse)",
+      "openButton": "Mein verlauf",
+      "suggestionResults": "(keine Ergebnisse) | ({count} Ergebnis) | ({count} Ergebnisse)",
       "switch": {
         "title": "Verlaufsanfragen",
         "enable": "Aktivieren",
@@ -36,7 +36,7 @@
       }
     },
     "nextQueries": {
-      "title": "Was kommt als Nächstes"
+      "title": "Was kommt als nächstes"
     },
     "nextQueriesGroup": {
       "message": "Diejenigen, die nach {query} gesucht haben, haben auch angesehen:"
@@ -66,8 +66,8 @@
       "runtimeMinutes": "Dauer in Minuten"
     },
     "facetsPanel": {
-      "title": "SORTIEREN & FILTERN",
-      "viewResults": "ERGEBNISSE ANZEIGEN ({totalResults})"
+      "title": "Sortieren & filtern",
+      "viewResults": "1 Ergebnis anzeigen | {count} Ergebnisse anzeigen"
     },
     "filters": {
       "all": "Alle",
@@ -85,10 +85,10 @@
       "from": "ab {'{min}'}"
     },
     "toggleAside": {
-      "showAside": "Sortieren & Filtern"
+      "showAside": "Sortieren & filtern"
     },
     "totalResults": {
-      "message": "{totalResults} Ergebnisse für {query}"
+      "message": "1 Ergebnis für {query} | {totalResults} Ergebnisse für {query}"
     },
     "semanticQueries": {
       "title": "Sind Sie an „{query}“ interessiert? Entdecken Sie diese Vorschläge:"
@@ -102,10 +102,10 @@
       }
     },
     "selectedFilters": {
-      "clear": "FILTER LÖSCHEN ({selectedFiltersNumber})"
+      "clear": "1 Filter löschen | {count} Filter löschen"
     },
     "result": {
-      "addToCart": "IN DEN WARENKORB LEGEN"
+      "addToCart": "In den Warenkorb legen"
     },
     "spellcheck": {
       "message": "Keine Ergebnisse gefunden für {query}. Wir zeigen Ihnen Ergebnisse für"
@@ -140,7 +140,7 @@
       "viewResults": "Alle anzeigen"
     },
     "totalResults": {
-      "message": "{totalResults} Ergebnisse"
+      "message": "1 Ergebnis | {totalResults} Ergebnisse"
     },
     "queryPreview": {
       "viewResults": "Alle anzeigen"

--- a/src/i18n/messages/en.messages.json
+++ b/src/i18n/messages/en.messages.json
@@ -5,15 +5,15 @@
       "placeholder": "What are you looking for?"
     },
     "popularSearches": {
-      "title": "Popular Searches"
+      "title": "Popular searches"
     },
     "historyQueries": {
       "clear": "Clear all",
       "removeLabel": "Remove {suggestion} from history queries",
-      "title": "History Queries"
+      "title": "History queries"
     },
     "myHistory": {
-      "title": "My History",
+      "title": "My history",
       "subtitle": "This is the complete list of history queries",
       "message": {
         "header": "This data is stored locally. Just in your device and never travel outside of it.",
@@ -21,10 +21,10 @@
         "footer": "Your privacy under your control."
       },
       "noHistory": "No history activity to show",
-      "openButton": "My History",
-      "suggestionResults": "({totalResults} results)",
+      "openButton": "My history",
+      "suggestionResults": "(no results) | ({count} result) | ({count} results)",
       "switch": {
-        "title": "History Queries",
+        "title": "History queries",
         "enable": "Enable",
         "disable": "Disable and clear"
       },
@@ -36,7 +36,7 @@
       }
     },
     "nextQueries": {
-      "title": "What's Next"
+      "title": "What's next"
     },
     "nextQueriesGroup": {
       "message": "Those who searched for {query} also viewed:"
@@ -48,10 +48,10 @@
       "viewResults": "View all results"
     },
     "identifierResults": {
-      "title": "SKU Search"
+      "title": "SKU search"
     },
     "recommendations": {
-      "title": "Top Clicked"
+      "title": "Top clicked"
     },
     "facets": {
       "gender": "Gender",
@@ -61,13 +61,13 @@
       "fit": "Fit",
       "collection": "Collection",
       "genres": "Genres",
-      "isAdult": "Is Adult",
+      "isAdult": "Is adult",
       "type": "Type",
       "runtimeMinutes": "Runtime minutes"
     },
     "facetsPanel": {
-      "title": "SORT & FILTER",
-      "viewResults": "VIEW {totalResults} RESULTS"
+      "title": "Sort & filter",
+      "viewResults": "View 1 result | View {count} results"
     },
     "filters": {
       "all": "All",
@@ -85,10 +85,10 @@
       "from": "from {'{min}'}"
     },
     "toggleAside": {
-      "showAside": "Sort & Filter"
+      "showAside": "Sort & filter"
     },
     "totalResults": {
-      "message": "{totalResults} results for {query}"
+      "message": "1 result for {query} | {totalResults} results for {query}"
     },
     "semanticQueries": {
       "title": "Are you interested in \"{query}\"? Explore this suggestions:"
@@ -102,10 +102,10 @@
       }
     },
     "selectedFilters": {
-      "clear": "CLEAR {selectedFiltersNumber} FILTERS"
+      "clear": "Clear 1 filter | Clear {count} filters"
     },
     "result": {
-      "addToCart": "ADD TO CART"
+      "addToCart": "Add to cart"
     },
     "spellcheck": {
       "message": "No results found for {query} We show you results for"
@@ -140,7 +140,7 @@
       "viewResults": "View all"
     },
     "totalResults": {
-      "message": "{totalResults} results"
+      "message": "{totalResults} result | {totalResults} results"
     },
     "queryPreview": {
       "viewResults": "View all"

--- a/src/i18n/messages/es.messages.json
+++ b/src/i18n/messages/es.messages.json
@@ -5,7 +5,7 @@
       "placeholder": "¿Qué estás buscando?"
     },
     "popularSearches": {
-      "title": "Búsquedas Populares"
+      "title": "Búsquedas populares"
     },
     "historyQueries": {
       "clear": "Limpiar historial",
@@ -13,7 +13,7 @@
       "title": "Historial"
     },
     "myHistory": {
-      "title": "Mi Historial",
+      "title": "Mi historial",
       "subtitle": "Este es tu historial de búsqueda",
       "message": {
         "header": "Los datos se guardan en local. Solo están en tu dispositivo y nunca salen de ahí.",
@@ -21,8 +21,8 @@
         "footer": "Tu privacidad bajo tu control."
       },
       "noHistory": "No hay historial de búsqueda para mostrar",
-      "openButton": "Mi Historial",
-      "suggestionResults": "({totalResults} resultados)",
+      "openButton": "Mi historial",
+      "suggestionResults": "(sin resultados) | (1 resultado) | ({count} resultados)",
       "switch": {
         "title": "Historial de búsqueda",
         "enable": "Activar",
@@ -36,7 +36,7 @@
       }
     },
     "nextQueries": {
-      "title": "Quizás te Interese"
+      "title": "Quizás te interese"
     },
     "nextQueriesGroup": {
       "message": "Los que buscaron {query} también han visto:"
@@ -51,7 +51,7 @@
       "title": "Búsqueda SKU"
     },
     "recommendations": {
-      "title": "Top Clicked"
+      "title": "Top clicked"
     },
     "facets": {
       "gender": "Género",
@@ -61,13 +61,13 @@
       "fit": "Fit",
       "collection": "Colección",
       "genres": "Géneros",
-      "isAdult": "Contenido Adulto",
+      "isAdult": "Contenido adulto",
       "type": "Tipo",
       "runtimeMinutes": "Minutos de duración"
     },
     "facetsPanel": {
-      "title": "ORDENAR & FILTRAR",
-      "viewResults": "VER {totalResults} RESULTADOS"
+      "title": "Ordenar y filtrar",
+      "viewResults": "Ver 1 resultado | Ver {count} resultados"
     },
     "filters": {
       "all": "Todo",
@@ -85,10 +85,10 @@
       "from": "desde {'{min}'}"
     },
     "toggleAside": {
-      "showAside": "Ordenar y Filtrar"
+      "showAside": "Ordenar y filtrar"
     },
     "totalResults": {
-      "message": "{totalResults} resultados para {query}"
+      "message": "1 resultado para {query} | {totalResults} resultados para {query}"
     },
     "semanticQueries": {
       "title": "¿Estás interesado en \"{query}\"? Explora estas sugerencias:"
@@ -102,10 +102,10 @@
       }
     },
     "selectedFilters": {
-      "clear": "LIMPIAR {selectedFiltersNumber} FILTROS"
+      "clear": "Limpiar 1 filtro | Limpiar {count} filtros"
     },
     "result": {
-      "addToCart": "AÑADIR AL CARRITO"
+      "addToCart": "Añadir al carrito"
     },
     "spellcheck": {
       "message": "No se han encontrado resultados para {query} Aquí tienes resultados para"
@@ -140,7 +140,7 @@
       "viewResults": "Ver todos"
     },
     "totalResults": {
-      "message": "{totalResults} resultados"
+      "message": "{totalResults} resultado | {totalResults} resultados"
     },
     "queryPreview": {
       "viewResults": "Ver todo"

--- a/src/i18n/messages/fr.messages.json
+++ b/src/i18n/messages/fr.messages.json
@@ -5,12 +5,12 @@
       "placeholder": "Que cherchez-vous?"
     },
     "popularSearches": {
-      "title": "Recherches Populaires"
+      "title": "Recherches populaires"
     },
     "historyQueries": {
       "clear": "Tout effacer",
       "removeLabel": "Supprimer {suggestion} des requêtes d'historique",
-      "title": "Recherches D'historique"
+      "title": "Recherches d'historique"
     },
     "myHistory": {
       "title": "Mon histoire",
@@ -22,7 +22,7 @@
       },
       "noHistory": "Aucune activité d'historique à afficher",
       "openButton": "Mon histoire",
-      "suggestionResults": "({totalResults} résultats)",
+      "suggestionResults": "(aucun résultat) | ({count} résultat) | ({count} résultats)",
       "switch": {
         "title": "Requêtes d'historique",
         "enable": "Activer",
@@ -36,7 +36,7 @@
       }
     },
     "nextQueries": {
-      "title": "Et Après"
+      "title": "Et après"
     },
     "nextQueriesGroup": {
       "message": "Ceux qui cherchaient {query} également consulté:"
@@ -48,7 +48,7 @@
       "viewResults": "Voir tous les résultats"
     },
     "identifierResults": {
-      "title": "SKU Chercher"
+      "title": "SKU chercher"
     },
     "recommendations": {
       "title": "Top cliqué"
@@ -66,8 +66,8 @@
       "runtimeMinutes": "Durée en minutes"
     },
     "facetsPanel": {
-      "title": "TRIER ET FILTRER",
-      "viewResults": "VOIR {totalResults} RÉSULTATS"
+      "title": "Trier et filtrer",
+      "viewResults": "Voir 1 résultat | Voir {count} résultats"
     },
     "filters": {
       "all": "Tout",
@@ -88,7 +88,7 @@
       "showAside": "Trier et filtrer"
     },
     "totalResults": {
-      "message": "{totalResults} résultats pour {query}"
+      "message": "1 résultat pour {query} | {totalResults} résultats pour {query}"
     },
     "semanticQueries": {
       "title": "Êtes-vous intéressé par «{query}»? Explorez ces suggestions:"
@@ -102,10 +102,10 @@
       }
     },
     "selectedFilters": {
-      "clear": "EFFACER {selectedFiltersNumber} FILTRES"
+      "clear": "Effacer 1 filtre | Effacer {count} filtres"
     },
     "result": {
-      "addToCart": "AJOUTER AU PANIER"
+      "addToCart": "Ajouter au panier"
     },
     "spellcheck": {
       "message": "Aucun résultat trouvé pour {query} Nous vous montrons les résultats pour"
@@ -140,7 +140,7 @@
       "viewResults": "Voir tout"
     },
     "totalResults": {
-      "message": "{totalResults} résultats"
+      "message": "1 résultat | {totalResults} résultats"
     },
     "queryPreview": {
       "viewResults": "Voir tout"

--- a/src/i18n/messages/it.messages.json
+++ b/src/i18n/messages/it.messages.json
@@ -22,7 +22,7 @@
       },
       "noHistory": "La cronologia e' vuota",
       "openButton": "Cronologia",
-      "suggestionResults": "({totalResults} risultati)",
+      "suggestionResults": "(nessun risultato) | ({count} risultato) | ({count} risultati)",
       "switch": {
         "title": "Cronologia ricerche",
         "enable": "Attiva",
@@ -51,7 +51,7 @@
       "title": "Ricerca SKU"
     },
     "recommendations": {
-      "title": "Top Cliccati"
+      "title": "Top cliccati"
     },
     "facets": {
       "gender": "Genere",
@@ -66,8 +66,8 @@
       "runtimeMinutes": "Durata minuti"
     },
     "facetsPanel": {
-      "title": "ORDINA & FILTRA",
-      "viewResults": "MOSTRA {totalResults} RISULTATI"
+      "title": "Ordina & filtra",
+      "viewResults": "Vedi 1 risultato | Vedi {count} risultati"
     },
     "filters": {
       "all": "Tutto",
@@ -88,7 +88,7 @@
       "showAside": "Ordina & Filtra"
     },
     "totalResults": {
-      "message": "{totalResults} risultati per {query}"
+      "message": "1 risultato per {query} | {totalResults} risultati per {query}"
     },
     "semanticQueries": {
       "title": "Ti interessa \"{query}\"? Esplora questi suggerimenti:"
@@ -102,10 +102,10 @@
       }
     },
     "selectedFilters": {
-      "clear": "RIMUOVI {selectedFiltersNumber} FILTRI"
+      "clear": "Rimuovi 1 filtro | Rimuovi {count} filtri"
     },
     "result": {
-      "addToCart": "AGGIUNGI AL CARRELLO"
+      "addToCart": "Aggiungi al carrello"
     },
     "spellcheck": {
       "message": "Nessun risultato trovato per {query} Ecco i risultati per"
@@ -140,7 +140,7 @@
       "viewResults": "Mostra tutti"
     },
     "totalResults": {
-      "message": "{totalResults} risultati"
+      "message": "1 risultato | {totalResults} risultati"
     },
     "queryPreview": {
       "viewResults": "Mostra tutti"

--- a/src/i18n/messages/pt.messages.json
+++ b/src/i18n/messages/pt.messages.json
@@ -5,12 +5,12 @@
       "placeholder": "O que você está procurando?"
     },
     "popularSearches": {
-      "title": "Buscas Populares"
+      "title": "Buscas populares"
     },
     "historyQueries": {
       "clear": "Limpar histórico",
       "removeLabel": "Limpar {suggestion} histórico de buscas",
-      "title": "Histórico de Buscas"
+      "title": "Histórico de buscas"
     },
     "myHistory": {
       "title": "Meu histórico",
@@ -22,7 +22,7 @@
       },
       "noHistory": "Não há histórico de buscas para mostrar",
       "openButton": "Meu histórico",
-      "suggestionResults": "({totalResults} resultados)",
+      "suggestionResults": "(nenhum resultado) | ({count} resultado) | ({count} resultados)",
       "switch": {
         "title": "Histórico de buscas",
         "enable": "Ativo",
@@ -36,7 +36,7 @@
       }
     },
     "nextQueries": {
-      "title": "Você Pode se Interessar"
+      "title": "Você pode se interessar"
     },
     "nextQueriesGroup": {
       "message": "Aqueles que pesquisaram por {query} também viram:"
@@ -66,8 +66,8 @@
       "runtimeMinutes": "Duração em minutos"
     },
     "facetsPanel": {
-      "title": "ORDENAR & FILTRAR",
-      "viewResults": "VER {totalResults} RESULTADOS"
+      "title": "Ordenar e filtrar",
+      "viewResults": "Ver 1 resultado | Ver {count} resultados"
     },
     "filters": {
       "all": "Todo",
@@ -88,7 +88,7 @@
       "showAside": "Ordenar e Filtrar"
     },
     "totalResults": {
-      "message": "{totalResults} resultados para {query}"
+      "message": "1 resultado para {query} | {totalResults} resultados para {query}"
     },
     "semanticQueries": {
       "title": "Você está interessado em \"{query}\"? Explore estas sugestões:"
@@ -102,10 +102,10 @@
       }
     },
     "selectedFilters": {
-      "clear": "LIMPAR {selectedFiltersNumber} FILTROS"
+      "clear": "Limpar 1 filtro | Limpar {count} filtros"
     },
     "result": {
-      "addToCart": "ADICIONAR AO CARRINHO"
+      "addToCart": "Adicionar ao carrinho"
     },
     "spellcheck": {
       "message": "Sem resultados encontrados para {query} Aqui estão os resultados para"
@@ -140,7 +140,7 @@
       "viewResults": "Ver todos"
     },
     "totalResults": {
-      "message": "{totalResults} resultados"
+      "message": "1 resultado | {totalResults} resultados"
     },
     "queryPreview": {
       "viewResults": "Ver todos"


### PR DESCRIPTION
[RST-3983](https://searchbroker.atlassian.net/browse/RST-3983)

[RST-3983]: https://searchbroker.atlassian.net/browse/RST-3983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Take into account:** 
 In vue-i18n v9, when you use pluralization, the count you pass as the second argument is not automatically available for interpolation unless your placeholder is named {count}. So, some placeholders have been renamed to work properly.