### PR TITLE
feat: add feature flag composable

### DIFF
--- a/src/composables/use-environment.composable.ts
+++ b/src/composables/use-environment.composable.ts
@@ -1,0 +1,52 @@
+import type { SnippetConfig } from '@empathyco/x-components'
+import type { ComputedRef } from 'vue'
+import { computed, inject } from 'vue'
+
+const PRO = 'PRODUCTION'
+const STA = 'STAGING'
+const DEV = 'DEVELOPMENT'
+
+/**
+ *
+ * Composable to access and check environment variables.
+ *
+ * @returns An object with methods to get environment variables and check environment state.
+ */
+export function useEnvironment(): {
+  currentEnvironment: ComputedRef<string>
+  isProd: ComputedRef<boolean>
+} {
+  const snippetConfig = inject<SnippetConfig>('snippetConfig')
+
+  /**
+   * Gets the environment value reactively.
+   *
+   * NOTE: If env is undefined or unrecognized, as security measure, we assume production.
+   *
+   * @returns The environment value or undefined.
+   */
+  const currentEnvironment = computed(() => {
+    switch (snippetConfig?.env as string) {
+      case '':
+        return PRO
+      case 'staging':
+        return STA
+      case 'test':
+        return DEV
+      default:
+        return PRO
+    }
+  })
+
+  /**
+   * Checks if the current environment is production.
+   *
+   * @returns True if in production environment.
+   */
+  const isProd = computed(() => currentEnvironment.value === PRO)
+
+  return {
+    currentEnvironment,
+    isProd,
+  }
+}

--- a/src/composables/use-feature-flags.composable.ts
+++ b/src/composables/use-feature-flags.composable.ts
@@ -1,0 +1,59 @@
+import type { ComputedRef } from 'vue'
+import { computed } from 'vue'
+import { useEnvironment } from './use-environment.composable'
+
+/**
+ * Enum of feature flag keys to prevent typing errors.
+ */
+export enum FeatureFlag {
+  TELEPORT_FEATURE = 'RST-8888-teleport-feature',
+  RELATED_PROMPTS = 'RST-9999-related-prompts',
+  // Add new feature flags here
+}
+
+/**
+ * Static feature flags configuration.
+ * Add new features here with their production status.
+ */
+export const FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
+  // Examples:
+  [FeatureFlag.TELEPORT_FEATURE]: false, // Not ready for production
+  [FeatureFlag.RELATED_PROMPTS]: true, // Enabled in production
+}
+
+/**
+ * Simplified composable to check feature flags.
+ *
+ * @returns Method to check if features are enabled.
+ */
+export function useFeatureFlags(): {
+  isFeatureEnabled: (featureId: FeatureFlag) => ComputedRef<boolean>
+} {
+  const { isProd } = useEnvironment()
+
+  /**
+   * Checks if a feature should be visible
+   * - In production: only if the feature flag is set to true
+   * - In non-production: always visible for testing purposes.
+   *
+   * @param featureId - The ID of the feature to check.
+   * @returns Whether the feature should be visible.
+   */
+  function isFeatureEnabled(featureId: FeatureFlag): ComputedRef<boolean> {
+    return computed(() => {
+      // If feature is not registered, warn and disable it
+      if (FEATURE_FLAGS[featureId] === undefined) {
+        console.warn(`Feature "${featureId}" not registered in FEATURE_FLAGS. Disabling it.`)
+        return false
+      }
+
+      // In production, respect the static flag value
+      // In non-production environments, always enable the feature
+      return isProd.value ? FEATURE_FLAGS[featureId] : true
+    })
+  }
+
+  return {
+    isFeatureEnabled,
+  }
+}


### PR DESCRIPTION
This new composable lets us toggle features on and off. Here's what it does:

- Makes it super easy to hide or show features based on simple flags
- Uses TypeScript to catch typos and give nice auto-completion
- Keeps all feature flags in one place for easy management
- Allows merging to main when a feature is done, and performs releases containing no executable code.

Use example:

```
import { FeatureFlag, useFeatureFlags } from '../composables/use-feature-flags.composable';

const { isFeatureEnabled } = useFeatureFlags();
    
const teleportFeature = isFeatureEnabled(FeatureFlag.TELEPORT_FEATURE);
```
